### PR TITLE
chore(package): rename to scoped package @jgardner04/ghost-mcp-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "./mcp": "./src/mcp_server_improved.js"
   },
   "bin": {
-    "ghost-mcp-server": "src/index.js",
-    "ghost-mcp": "src/mcp_server_improved.js"
+    "ghost-mcp-server": "./src/index.js",
+    "ghost-mcp": "./src/mcp_server_improved.js"
   },
   "files": [
     "src",


### PR DESCRIPTION
## Summary
Rename the npm package from `ghost-mcp-server` to `@jgardner04/ghost-mcp-server`.

## Changes
- Updated `name` field in `package.json` to use scoped package name

## Notes
- The `publishConfig.access: "public"` is already set, ensuring the scoped package publishes publicly
- Users will install with: `npm install @jgardner04/ghost-mcp-server`