### PR TITLE
fix: add lint and test steps to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run linting
+        run: npm run lint
+
+      - name: Run tests
+        run: npm run test:coverage
+
       - name: Security audit
         run: npm audit --audit-level=high
 


### PR DESCRIPTION
## Summary
This PR adds linting and test execution steps to the GitHub Actions CI workflow.

## Changes
- Added `Run linting` step that executes `npm run lint`
- Added `Run tests` step that executes `npm run test:coverage`
- Steps are positioned in the correct order: after dependency installation and before build
- CI will now fail if lint errors are found
- CI will now fail if tests fail or coverage drops below 80%

## Dependencies
- Requires: #17 (ESLint/Prettier setup) ✅ merged
- Requires: #16 (Vitest setup) ✅ merged

## Acceptance Criteria
- [x] CI pipeline includes lint step
- [x] CI pipeline includes test:coverage step
- [x] PR checks will fail if lint errors exist
- [x] PR checks will fail if coverage drops below 80%

Fixes #30