### PR TITLE
fix: exclude experimental files from test coverage

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -22,6 +22,10 @@ export default defineConfig({
         '**/__tests__/**',
         '**/*.test.js',
         '**/*.spec.js',
+        // Exclude experimental/variant files from coverage
+        'src/mcp_server_improved.js',
+        'src/mcp_server_enhanced.js',
+        'src/services/ghostServiceImproved.js',
       ],
     },
     include: ['src/**/*.test.js', 'src/**/*.spec.js', 'src/**/__tests__/**/*.js'],


### PR DESCRIPTION
## Summary
Fixes #37 

This PR excludes experimental/variant files from test coverage metrics to focus coverage reporting on production code only.

## Changes
- Updated `vitest.config.js` to exclude experimental files from coverage:
  - `src/mcp_server_improved.js`
  - `src/mcp_server_enhanced.js`
  - `src/services/ghostServiceImproved.js`

## Impact
- Coverage metrics now accurately reflect production code coverage
- The coverage denominator decreases (fewer files to measure)
- Experimental files are still present in the codebase but won't affect coverage percentages

## Testing
- ✅ All existing tests pass
- ✅ Coverage report no longer includes experimental files
- ✅ Pre-commit and pre-push hooks pass

## Verification
Run `npm run test:coverage` to see that the experimental files are no longer listed in the coverage report.