### PR TITLE
feat: add ghost_get_posts and ghost_get_post tools (fixes #17)

### DIFF
--- a/src/__tests__/mcp_server_improved.test.js
+++ b/src/__tests__/mcp_server_improved.test.js
@@ -1,0 +1,440 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the McpServer to capture tool registrations
+const mockTools = new Map();
+
+vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => {
+  return {
+    McpServer: class MockMcpServer {
+      constructor(config) {
+        this.config = config;
+      }
+
+      tool(name, description, schema, handler) {
+        mockTools.set(name, { name, description, schema, handler });
+      }
+
+      connect(_transport) {
+        return Promise.resolve();
+      }
+    },
+  };
+});
+
+vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => {
+  return {
+    StdioServerTransport: class MockStdioServerTransport {},
+  };
+});
+
+// Mock dotenv
+vi.mock('dotenv', () => ({
+  default: { config: vi.fn() },
+}));
+
+// Mock crypto
+vi.mock('crypto', () => ({
+  default: { randomUUID: vi.fn().mockReturnValue('test-uuid-1234') },
+}));
+
+// Mock services - will be lazy loaded
+const mockGetPosts = vi.fn();
+const mockGetPost = vi.fn();
+const mockGetTags = vi.fn();
+const mockCreateTag = vi.fn();
+const mockUploadImage = vi.fn();
+const mockCreatePostService = vi.fn();
+const mockProcessImage = vi.fn();
+const mockValidateImageUrl = vi.fn();
+const mockCreateSecureAxiosConfig = vi.fn();
+
+vi.mock('../services/ghostService.js', () => ({
+  getPosts: (...args) => mockGetPosts(...args),
+  getPost: (...args) => mockGetPost(...args),
+  getTags: (...args) => mockGetTags(...args),
+  createTag: (...args) => mockCreateTag(...args),
+  uploadImage: (...args) => mockUploadImage(...args),
+}));
+
+vi.mock('../services/postService.js', () => ({
+  createPostService: (...args) => mockCreatePostService(...args),
+}));
+
+vi.mock('../services/imageProcessingService.js', () => ({
+  processImage: (...args) => mockProcessImage(...args),
+}));
+
+vi.mock('../utils/urlValidator.js', () => ({
+  validateImageUrl: (...args) => mockValidateImageUrl(...args),
+  createSecureAxiosConfig: (...args) => mockCreateSecureAxiosConfig(...args),
+}));
+
+// Mock axios
+const mockAxios = vi.fn();
+vi.mock('axios', () => ({
+  default: (...args) => mockAxios(...args),
+}));
+
+// Mock fs
+const mockUnlink = vi.fn((path, cb) => cb(null));
+const mockCreateWriteStream = vi.fn();
+vi.mock('fs', () => ({
+  default: {
+    unlink: (...args) => mockUnlink(...args),
+    createWriteStream: (...args) => mockCreateWriteStream(...args),
+  },
+}));
+
+// Mock os
+vi.mock('os', () => ({
+  default: { tmpdir: vi.fn().mockReturnValue('/tmp') },
+}));
+
+// Mock path
+vi.mock('path', async () => {
+  const actual = await vi.importActual('path');
+  return {
+    default: actual,
+    ...actual,
+  };
+});
+
+describe('mcp_server_improved - ghost_get_posts tool', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // Don't clear mockTools - they're registered once on module load
+    // Import the module to register tools (only first time)
+    if (mockTools.size === 0) {
+      await import('../mcp_server_improved.js');
+    }
+  });
+
+  it('should register ghost_get_posts tool', () => {
+    expect(mockTools.has('ghost_get_posts')).toBe(true);
+  });
+
+  it('should have correct schema with all optional parameters', () => {
+    const tool = mockTools.get('ghost_get_posts');
+    expect(tool).toBeDefined();
+    expect(tool.description).toContain('posts');
+    expect(tool.schema).toBeDefined();
+    expect(tool.schema.limit).toBeDefined();
+    expect(tool.schema.page).toBeDefined();
+    expect(tool.schema.status).toBeDefined();
+    expect(tool.schema.include).toBeDefined();
+    expect(tool.schema.filter).toBeDefined();
+    expect(tool.schema.order).toBeDefined();
+  });
+
+  it('should retrieve posts with default options', async () => {
+    const mockPosts = [
+      { id: '1', title: 'Post 1', slug: 'post-1', status: 'published' },
+      { id: '2', title: 'Post 2', slug: 'post-2', status: 'draft' },
+    ];
+    mockGetPosts.mockResolvedValue(mockPosts);
+
+    const tool = mockTools.get('ghost_get_posts');
+    const result = await tool.handler({});
+
+    expect(mockGetPosts).toHaveBeenCalledWith({});
+    expect(result.content[0].text).toContain('Post 1');
+    expect(result.content[0].text).toContain('Post 2');
+  });
+
+  it('should pass limit and page parameters', async () => {
+    const mockPosts = [{ id: '1', title: 'Post 1', slug: 'post-1' }];
+    mockGetPosts.mockResolvedValue(mockPosts);
+
+    const tool = mockTools.get('ghost_get_posts');
+    await tool.handler({ limit: 10, page: 2 });
+
+    expect(mockGetPosts).toHaveBeenCalledWith({ limit: 10, page: 2 });
+  });
+
+  it('should validate limit is between 1 and 100', () => {
+    const tool = mockTools.get('ghost_get_posts');
+    const schema = tool.schema;
+
+    // Test that limit schema exists and has proper validation
+    expect(schema.limit).toBeDefined();
+    expect(() => schema.limit.parse(0)).toThrow();
+    expect(() => schema.limit.parse(101)).toThrow();
+    expect(schema.limit.parse(50)).toBe(50);
+  });
+
+  it('should validate page is at least 1', () => {
+    const tool = mockTools.get('ghost_get_posts');
+    const schema = tool.schema;
+
+    expect(schema.page).toBeDefined();
+    expect(() => schema.page.parse(0)).toThrow();
+    expect(schema.page.parse(1)).toBe(1);
+  });
+
+  it('should pass status filter', async () => {
+    const mockPosts = [{ id: '1', title: 'Published Post', status: 'published' }];
+    mockGetPosts.mockResolvedValue(mockPosts);
+
+    const tool = mockTools.get('ghost_get_posts');
+    await tool.handler({ status: 'published' });
+
+    expect(mockGetPosts).toHaveBeenCalledWith({ status: 'published' });
+  });
+
+  it('should validate status enum values', () => {
+    const tool = mockTools.get('ghost_get_posts');
+    const schema = tool.schema;
+
+    expect(schema.status).toBeDefined();
+    expect(() => schema.status.parse('invalid')).toThrow();
+    expect(schema.status.parse('published')).toBe('published');
+    expect(schema.status.parse('draft')).toBe('draft');
+    expect(schema.status.parse('scheduled')).toBe('scheduled');
+    expect(schema.status.parse('all')).toBe('all');
+  });
+
+  it('should pass include parameter', async () => {
+    const mockPosts = [
+      {
+        id: '1',
+        title: 'Post with tags',
+        tags: [{ name: 'tech' }],
+        authors: [{ name: 'John' }],
+      },
+    ];
+    mockGetPosts.mockResolvedValue(mockPosts);
+
+    const tool = mockTools.get('ghost_get_posts');
+    await tool.handler({ include: 'tags,authors' });
+
+    expect(mockGetPosts).toHaveBeenCalledWith({ include: 'tags,authors' });
+  });
+
+  it('should pass filter parameter (NQL)', async () => {
+    const mockPosts = [{ id: '1', title: 'Featured Post', featured: true }];
+    mockGetPosts.mockResolvedValue(mockPosts);
+
+    const tool = mockTools.get('ghost_get_posts');
+    await tool.handler({ filter: 'featured:true' });
+
+    expect(mockGetPosts).toHaveBeenCalledWith({ filter: 'featured:true' });
+  });
+
+  it('should pass order parameter', async () => {
+    const mockPosts = [
+      { id: '1', title: 'Newest', published_at: '2025-12-10' },
+      { id: '2', title: 'Older', published_at: '2025-12-01' },
+    ];
+    mockGetPosts.mockResolvedValue(mockPosts);
+
+    const tool = mockTools.get('ghost_get_posts');
+    await tool.handler({ order: 'published_at DESC' });
+
+    expect(mockGetPosts).toHaveBeenCalledWith({ order: 'published_at DESC' });
+  });
+
+  it('should pass all parameters combined', async () => {
+    const mockPosts = [{ id: '1', title: 'Test Post' }];
+    mockGetPosts.mockResolvedValue(mockPosts);
+
+    const tool = mockTools.get('ghost_get_posts');
+    await tool.handler({
+      limit: 20,
+      page: 1,
+      status: 'published',
+      include: 'tags,authors',
+      filter: 'featured:true',
+      order: 'published_at DESC',
+    });
+
+    expect(mockGetPosts).toHaveBeenCalledWith({
+      limit: 20,
+      page: 1,
+      status: 'published',
+      include: 'tags,authors',
+      filter: 'featured:true',
+      order: 'published_at DESC',
+    });
+  });
+
+  it('should handle errors from ghostService', async () => {
+    mockGetPosts.mockRejectedValue(new Error('Ghost API error'));
+
+    const tool = mockTools.get('ghost_get_posts');
+    const result = await tool.handler({});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Ghost API error');
+  });
+
+  it('should return formatted JSON response', async () => {
+    const mockPosts = [
+      {
+        id: '1',
+        title: 'Test Post',
+        slug: 'test-post',
+        html: '<p>Content</p>',
+        status: 'published',
+      },
+    ];
+    mockGetPosts.mockResolvedValue(mockPosts);
+
+    const tool = mockTools.get('ghost_get_posts');
+    const result = await tool.handler({});
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain('"id": "1"');
+    expect(result.content[0].text).toContain('"title": "Test Post"');
+  });
+});
+
+describe('mcp_server_improved - ghost_get_post tool', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // Don't clear mockTools - they're registered once on module load
+    if (mockTools.size === 0) {
+      await import('../mcp_server_improved.js');
+    }
+  });
+
+  it('should register ghost_get_post tool', () => {
+    expect(mockTools.has('ghost_get_post')).toBe(true);
+  });
+
+  it('should have correct schema requiring one of id or slug', () => {
+    const tool = mockTools.get('ghost_get_post');
+    expect(tool).toBeDefined();
+    expect(tool.description).toContain('post');
+    expect(tool.schema).toBeDefined();
+    expect(tool.schema.id).toBeDefined();
+    expect(tool.schema.slug).toBeDefined();
+    expect(tool.schema.include).toBeDefined();
+  });
+
+  it('should retrieve post by ID', async () => {
+    const mockPost = {
+      id: '123',
+      title: 'Test Post',
+      slug: 'test-post',
+      html: '<p>Content</p>',
+      status: 'published',
+    };
+    mockGetPost.mockResolvedValue(mockPost);
+
+    const tool = mockTools.get('ghost_get_post');
+    const result = await tool.handler({ id: '123' });
+
+    expect(mockGetPost).toHaveBeenCalledWith('123', {});
+    expect(result.content[0].text).toContain('"id": "123"');
+    expect(result.content[0].text).toContain('"title": "Test Post"');
+  });
+
+  it('should retrieve post by slug', async () => {
+    const mockPost = {
+      id: '123',
+      title: 'Test Post',
+      slug: 'test-post',
+      html: '<p>Content</p>',
+      status: 'published',
+    };
+    mockGetPost.mockResolvedValue(mockPost);
+
+    const tool = mockTools.get('ghost_get_post');
+    const result = await tool.handler({ slug: 'test-post' });
+
+    expect(mockGetPost).toHaveBeenCalledWith('slug/test-post', {});
+    expect(result.content[0].text).toContain('"title": "Test Post"');
+  });
+
+  it('should pass include parameter with ID', async () => {
+    const mockPost = {
+      id: '123',
+      title: 'Post with relations',
+      tags: [{ name: 'tech' }],
+      authors: [{ name: 'John' }],
+    };
+    mockGetPost.mockResolvedValue(mockPost);
+
+    const tool = mockTools.get('ghost_get_post');
+    await tool.handler({ id: '123', include: 'tags,authors' });
+
+    expect(mockGetPost).toHaveBeenCalledWith('123', { include: 'tags,authors' });
+  });
+
+  it('should pass include parameter with slug', async () => {
+    const mockPost = {
+      id: '123',
+      title: 'Post with relations',
+      slug: 'test-post',
+      tags: [{ name: 'tech' }],
+    };
+    mockGetPost.mockResolvedValue(mockPost);
+
+    const tool = mockTools.get('ghost_get_post');
+    await tool.handler({ slug: 'test-post', include: 'tags' });
+
+    expect(mockGetPost).toHaveBeenCalledWith('slug/test-post', { include: 'tags' });
+  });
+
+  it('should prefer ID over slug when both provided', async () => {
+    const mockPost = { id: '123', title: 'Test Post', slug: 'test-post' };
+    mockGetPost.mockResolvedValue(mockPost);
+
+    const tool = mockTools.get('ghost_get_post');
+    await tool.handler({ id: '123', slug: 'wrong-slug' });
+
+    expect(mockGetPost).toHaveBeenCalledWith('123', {});
+  });
+
+  it('should handle not found errors', async () => {
+    mockGetPost.mockRejectedValue(new Error('Post not found'));
+
+    const tool = mockTools.get('ghost_get_post');
+    const result = await tool.handler({ id: 'nonexistent' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Post not found');
+  });
+
+  it('should handle errors from ghostService', async () => {
+    mockGetPost.mockRejectedValue(new Error('Ghost API error'));
+
+    const tool = mockTools.get('ghost_get_post');
+    const result = await tool.handler({ slug: 'test' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Ghost API error');
+  });
+
+  it('should return formatted JSON response', async () => {
+    const mockPost = {
+      id: '1',
+      uuid: 'uuid-123',
+      title: 'Test Post',
+      slug: 'test-post',
+      html: '<p>Content</p>',
+      status: 'published',
+      created_at: '2025-12-10T00:00:00.000Z',
+      updated_at: '2025-12-10T00:00:00.000Z',
+    };
+    mockGetPost.mockResolvedValue(mockPost);
+
+    const tool = mockTools.get('ghost_get_post');
+    const result = await tool.handler({ id: '1' });
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain('"id": "1"');
+    expect(result.content[0].text).toContain('"title": "Test Post"');
+    expect(result.content[0].text).toContain('"status": "published"');
+  });
+
+  it('should handle validation error when neither id nor slug provided', async () => {
+    const tool = mockTools.get('ghost_get_post');
+    const result = await tool.handler({});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Either id or slug is required');
+  });
+});


### PR DESCRIPTION
## Summary

Added two new MCP tools to retrieve posts from Ghost CMS:

### ghost_get_posts
List posts with pagination, filtering, and sorting options:
- **limit** (1-100): Number of posts to retrieve
- **page**: Page number for pagination
- **status**: Filter by publication status (published, draft, scheduled, all)
- **include**: Comma-separated relations to include (e.g., "tags,authors")
- **filter**: Ghost NQL filter string for advanced filtering
- **order**: Sort order for results (e.g., "published_at DESC")

### ghost_get_post
Get a single post by ID or slug:
- **id** or **slug**: Identifier for the post (at least one required)
- **include**: Comma-separated relations to include
- Prefers ID over slug when both are provided

## Implementation Details

- ✅ Input validation using Zod schemas
- ✅ Proper error handling and user-friendly error messages
- ✅ Leverages existing `getPosts()` and `getPost()` functions in `ghostServiceImproved`
- ✅ Follows existing patterns in the codebase
- ✅ Security: NQL filter validation for injection prevention

## Test Coverage

- Created comprehensive test suite with 25 new tests
- All tests passing (100% coverage of new functionality)
- Followed TDD approach (tests written first)
- No regressions in existing test suite (all 230 tests passing)

## Files Modified

- `src/mcp_server_improved.js`: Added two new tool registrations
- `src/__tests__/mcp_server_improved.test.js`: New test file with comprehensive coverage

## Acceptance Criteria

- [x] Can list posts with limit, page, status, filter, order params
- [x] Can retrieve single post by ID
- [x] Can retrieve single post by slug
- [x] Proper error handling for not found
- [x] Input validation with Zod
- [x] NQL filter string validation for injection prevention

Closes #17