### PR TITLE
feat: Add post management tools and comprehensive test coverage

### DIFF
--- a/src/__tests__/mcp_server_improved.test.js
+++ b/src/__tests__/mcp_server_improved.test.js
@@ -47,6 +47,8 @@ const mockCreatePostService = vi.fn();
 const mockProcessImage = vi.fn();
 const mockValidateImageUrl = vi.fn();
 const mockCreateSecureAxiosConfig = vi.fn();
+const mockUpdatePost = vi.fn();
+const mockDeletePost = vi.fn();
 
 vi.mock('../services/ghostService.js', () => ({
   getPosts: (...args) => mockGetPosts(...args),
@@ -58,6 +60,11 @@ vi.mock('../services/ghostService.js', () => ({
 
 vi.mock('../services/postService.js', () => ({
   createPostService: (...args) => mockCreatePostService(...args),
+}));
+
+vi.mock('../services/ghostServiceImproved.js', () => ({
+  updatePost: (...args) => mockUpdatePost(...args),
+  deletePost: (...args) => mockDeletePost(...args),
 }));
 
 vi.mock('../services/imageProcessingService.js', () => ({
@@ -436,5 +443,314 @@ describe('mcp_server_improved - ghost_get_post tool', () => {
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('Either id or slug is required');
+  });
+});
+
+describe('mcp_server_improved - ghost_update_post tool', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // Don't clear mockTools - they're registered once on module load
+    if (mockTools.size === 0) {
+      await import('../mcp_server_improved.js');
+    }
+  });
+
+  it('should register ghost_update_post tool', () => {
+    expect(mockTools.has('ghost_update_post')).toBe(true);
+  });
+
+  it('should have correct schema with required id field', () => {
+    const tool = mockTools.get('ghost_update_post');
+    expect(tool).toBeDefined();
+    expect(tool.description).toContain('Updates an existing post');
+    expect(tool.schema).toBeDefined();
+    expect(tool.schema.id).toBeDefined();
+    expect(tool.schema.title).toBeDefined();
+    expect(tool.schema.html).toBeDefined();
+    expect(tool.schema.status).toBeDefined();
+    expect(tool.schema.tags).toBeDefined();
+    expect(tool.schema.feature_image).toBeDefined();
+    expect(tool.schema.feature_image_alt).toBeDefined();
+    expect(tool.schema.feature_image_caption).toBeDefined();
+    expect(tool.schema.meta_title).toBeDefined();
+    expect(tool.schema.meta_description).toBeDefined();
+    expect(tool.schema.published_at).toBeDefined();
+    expect(tool.schema.custom_excerpt).toBeDefined();
+  });
+
+  it('should update post title', async () => {
+    const mockUpdatedPost = {
+      id: '123',
+      title: 'Updated Title',
+      slug: 'test-post',
+      html: '<p>Content</p>',
+      status: 'published',
+      updated_at: '2025-12-10T12:00:00.000Z',
+    };
+    mockUpdatePost.mockResolvedValue(mockUpdatedPost);
+
+    const tool = mockTools.get('ghost_update_post');
+    const result = await tool.handler({ id: '123', title: 'Updated Title' });
+
+    expect(mockUpdatePost).toHaveBeenCalledWith('123', { title: 'Updated Title' });
+    expect(result.content[0].text).toContain('"title": "Updated Title"');
+  });
+
+  it('should update post content', async () => {
+    const mockUpdatedPost = {
+      id: '123',
+      title: 'Test Post',
+      html: '<p>Updated content</p>',
+      status: 'published',
+      updated_at: '2025-12-10T12:00:00.000Z',
+    };
+    mockUpdatePost.mockResolvedValue(mockUpdatedPost);
+
+    const tool = mockTools.get('ghost_update_post');
+    const result = await tool.handler({ id: '123', html: '<p>Updated content</p>' });
+
+    expect(mockUpdatePost).toHaveBeenCalledWith('123', { html: '<p>Updated content</p>' });
+    expect(result.content[0].text).toContain('Updated content');
+  });
+
+  it('should update post status', async () => {
+    const mockUpdatedPost = {
+      id: '123',
+      title: 'Test Post',
+      html: '<p>Content</p>',
+      status: 'published',
+      updated_at: '2025-12-10T12:00:00.000Z',
+    };
+    mockUpdatePost.mockResolvedValue(mockUpdatedPost);
+
+    const tool = mockTools.get('ghost_update_post');
+    const result = await tool.handler({ id: '123', status: 'published' });
+
+    expect(mockUpdatePost).toHaveBeenCalledWith('123', { status: 'published' });
+    expect(result.content[0].text).toContain('"status": "published"');
+  });
+
+  it('should update post tags', async () => {
+    const mockUpdatedPost = {
+      id: '123',
+      title: 'Test Post',
+      html: '<p>Content</p>',
+      tags: [{ name: 'tech' }, { name: 'javascript' }],
+      updated_at: '2025-12-10T12:00:00.000Z',
+    };
+    mockUpdatePost.mockResolvedValue(mockUpdatedPost);
+
+    const tool = mockTools.get('ghost_update_post');
+    const result = await tool.handler({ id: '123', tags: ['tech', 'javascript'] });
+
+    expect(mockUpdatePost).toHaveBeenCalledWith('123', { tags: ['tech', 'javascript'] });
+    expect(result.content[0].text).toContain('tech');
+    expect(result.content[0].text).toContain('javascript');
+  });
+
+  it('should update post featured image', async () => {
+    const mockUpdatedPost = {
+      id: '123',
+      title: 'Test Post',
+      feature_image: 'https://example.com/new-image.jpg',
+      feature_image_alt: 'New image',
+      updated_at: '2025-12-10T12:00:00.000Z',
+    };
+    mockUpdatePost.mockResolvedValue(mockUpdatedPost);
+
+    const tool = mockTools.get('ghost_update_post');
+    const result = await tool.handler({
+      id: '123',
+      feature_image: 'https://example.com/new-image.jpg',
+      feature_image_alt: 'New image',
+    });
+
+    expect(mockUpdatePost).toHaveBeenCalledWith('123', {
+      feature_image: 'https://example.com/new-image.jpg',
+      feature_image_alt: 'New image',
+    });
+    expect(result.content[0].text).toContain('new-image.jpg');
+  });
+
+  it('should update SEO meta fields', async () => {
+    const mockUpdatedPost = {
+      id: '123',
+      title: 'Test Post',
+      meta_title: 'SEO Title',
+      meta_description: 'SEO Description',
+      updated_at: '2025-12-10T12:00:00.000Z',
+    };
+    mockUpdatePost.mockResolvedValue(mockUpdatedPost);
+
+    const tool = mockTools.get('ghost_update_post');
+    const result = await tool.handler({
+      id: '123',
+      meta_title: 'SEO Title',
+      meta_description: 'SEO Description',
+    });
+
+    expect(mockUpdatePost).toHaveBeenCalledWith('123', {
+      meta_title: 'SEO Title',
+      meta_description: 'SEO Description',
+    });
+    expect(result.content[0].text).toContain('SEO Title');
+    expect(result.content[0].text).toContain('SEO Description');
+  });
+
+  it('should update multiple fields at once', async () => {
+    const mockUpdatedPost = {
+      id: '123',
+      title: 'Updated Title',
+      html: '<p>Updated content</p>',
+      status: 'published',
+      tags: [{ name: 'tech' }],
+      updated_at: '2025-12-10T12:00:00.000Z',
+    };
+    mockUpdatePost.mockResolvedValue(mockUpdatedPost);
+
+    const tool = mockTools.get('ghost_update_post');
+    const result = await tool.handler({
+      id: '123',
+      title: 'Updated Title',
+      html: '<p>Updated content</p>',
+      status: 'published',
+      tags: ['tech'],
+    });
+
+    expect(mockUpdatePost).toHaveBeenCalledWith('123', {
+      title: 'Updated Title',
+      html: '<p>Updated content</p>',
+      status: 'published',
+      tags: ['tech'],
+    });
+    expect(result.content[0].text).toContain('Updated Title');
+  });
+
+  it('should handle not found errors', async () => {
+    mockUpdatePost.mockRejectedValue(new Error('Post not found'));
+
+    const tool = mockTools.get('ghost_update_post');
+    const result = await tool.handler({ id: 'nonexistent', title: 'New Title' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Post not found');
+  });
+
+  it('should handle validation errors', async () => {
+    mockUpdatePost.mockRejectedValue(new Error('Validation failed: Title is required'));
+
+    const tool = mockTools.get('ghost_update_post');
+    const result = await tool.handler({ id: '123', title: '' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Validation failed');
+  });
+
+  it('should handle Ghost API errors', async () => {
+    mockUpdatePost.mockRejectedValue(new Error('Ghost API error: Server timeout'));
+
+    const tool = mockTools.get('ghost_update_post');
+    const result = await tool.handler({ id: '123', title: 'Updated' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Ghost API error');
+  });
+
+  it('should return formatted JSON response', async () => {
+    const mockUpdatedPost = {
+      id: '123',
+      uuid: 'uuid-123',
+      title: 'Updated Post',
+      slug: 'updated-post',
+      html: '<p>Updated content</p>',
+      status: 'published',
+      created_at: '2025-12-09T00:00:00.000Z',
+      updated_at: '2025-12-10T12:00:00.000Z',
+    };
+    mockUpdatePost.mockResolvedValue(mockUpdatedPost);
+
+    const tool = mockTools.get('ghost_update_post');
+    const result = await tool.handler({ id: '123', title: 'Updated Post' });
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain('"id": "123"');
+    expect(result.content[0].text).toContain('"title": "Updated Post"');
+    expect(result.content[0].text).toContain('"status": "published"');
+  });
+});
+
+describe('mcp_server_improved - ghost_delete_post tool', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // Don't clear mockTools - they're registered once on module load
+    if (mockTools.size === 0) {
+      await import('../mcp_server_improved.js');
+    }
+  });
+
+  it('should register ghost_delete_post tool', () => {
+    expect(mockTools.has('ghost_delete_post')).toBe(true);
+  });
+
+  it('should have correct schema with required id field', () => {
+    const tool = mockTools.get('ghost_delete_post');
+    expect(tool).toBeDefined();
+    expect(tool.description).toContain('Deletes a post');
+    expect(tool.description).toContain('permanent');
+    expect(tool.schema).toBeDefined();
+    expect(tool.schema.id).toBeDefined();
+  });
+
+  it('should delete post by ID', async () => {
+    mockDeletePost.mockResolvedValue({ deleted: true });
+
+    const tool = mockTools.get('ghost_delete_post');
+    const result = await tool.handler({ id: '123' });
+
+    expect(mockDeletePost).toHaveBeenCalledWith('123');
+    expect(result.content[0].text).toContain('Post 123 has been successfully deleted');
+    expect(result.isError).toBeUndefined();
+  });
+
+  it('should handle not found errors', async () => {
+    mockDeletePost.mockRejectedValue(new Error('Post not found'));
+
+    const tool = mockTools.get('ghost_delete_post');
+    const result = await tool.handler({ id: 'nonexistent' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Post not found');
+  });
+
+  it('should handle Ghost API errors', async () => {
+    mockDeletePost.mockRejectedValue(new Error('Ghost API error: Permission denied'));
+
+    const tool = mockTools.get('ghost_delete_post');
+    const result = await tool.handler({ id: '123' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Ghost API error');
+  });
+
+  it('should return success message on successful deletion', async () => {
+    mockDeletePost.mockResolvedValue({ deleted: true });
+
+    const tool = mockTools.get('ghost_delete_post');
+    const result = await tool.handler({ id: 'test-post-id' });
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toBe('Post test-post-id has been successfully deleted.');
+  });
+
+  it('should handle network errors', async () => {
+    mockDeletePost.mockRejectedValue(new Error('Network error: Connection refused'));
+
+    const tool = mockTools.get('ghost_delete_post');
+    const result = await tool.handler({ id: '123' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Network error');
   });
 });


### PR DESCRIPTION
## Summary

- Add `ghost_get_posts` and `ghost_get_post` tools for retrieving posts (fixes #17)
- Add `ghost_update_post` and `ghost_delete_post` tools for modifying posts (fixes #18)
- Add comprehensive test coverage across the codebase (fixes #37-#45)

## New MCP Tools

### ghost_get_posts
Retrieves a list of posts with pagination, filtering, and sorting options.

### ghost_get_post  
Retrieves a single post by ID or slug.

### ghost_update_post
Updates an existing post - supports updating title, content, status, tags, images, and SEO fields.

### ghost_delete_post
Deletes a post by ID (permanent operation).

## Test Coverage Improvements

- Added shared test utilities and mocks (#38)
- Comprehensive tests for urlValidator utility (#39)
- Comprehensive tests for error handling system (#40)
- Expanded ghostService test coverage to 96%+ (#41)
- Tests for postService (#42)
- Tests for imageProcessingService (#43)
- Tests for logger utility (#44)
- Tests for controllers (#45)
- Tests for MCP server tools

## Test plan

- [x] All 618 tests passing
- [x] Linting passes
- [x] New tools follow existing patterns in codebase
- [x] Error handling follows project standards
- [x] Manual testing with Ghost CMS instance