### PR TITLE
feat: add page CRUD tools (get, create, update, delete, search)

### DIFF
--- a/src/__tests__/mcp_server_pages.test.js
+++ b/src/__tests__/mcp_server_pages.test.js
@@ -1,0 +1,520 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the McpServer to capture tool registrations
+const mockTools = new Map();
+
+vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => {
+  return {
+    McpServer: class MockMcpServer {
+      constructor(config) {
+        this.config = config;
+      }
+
+      tool(name, description, schema, handler) {
+        mockTools.set(name, { name, description, schema, handler });
+      }
+
+      connect(_transport) {
+        return Promise.resolve();
+      }
+    },
+  };
+});
+
+vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => {
+  return {
+    StdioServerTransport: class MockStdioServerTransport {},
+  };
+});
+
+// Mock dotenv
+vi.mock('dotenv', () => ({
+  default: { config: vi.fn() },
+}));
+
+// Mock crypto
+vi.mock('crypto', () => ({
+  default: { randomUUID: vi.fn().mockReturnValue('test-uuid-1234') },
+}));
+
+// Mock services for pages
+const mockGetPages = vi.fn();
+const mockGetPage = vi.fn();
+const mockUpdatePage = vi.fn();
+const mockDeletePage = vi.fn();
+const mockSearchPages = vi.fn();
+const mockCreatePageService = vi.fn();
+
+// Also mock post and tag services to avoid errors
+const mockGetPosts = vi.fn();
+const mockGetPost = vi.fn();
+const mockGetTags = vi.fn();
+const mockCreateTag = vi.fn();
+const mockUploadImage = vi.fn();
+const mockCreatePostService = vi.fn();
+const mockUpdatePost = vi.fn();
+const mockDeletePost = vi.fn();
+const mockSearchPosts = vi.fn();
+const mockProcessImage = vi.fn();
+const mockValidateImageUrl = vi.fn();
+const mockCreateSecureAxiosConfig = vi.fn();
+
+vi.mock('../services/ghostService.js', () => ({
+  getPosts: (...args) => mockGetPosts(...args),
+  getPost: (...args) => mockGetPost(...args),
+  getTags: (...args) => mockGetTags(...args),
+  createTag: (...args) => mockCreateTag(...args),
+  uploadImage: (...args) => mockUploadImage(...args),
+}));
+
+vi.mock('../services/postService.js', () => ({
+  createPostService: (...args) => mockCreatePostService(...args),
+}));
+
+vi.mock('../services/pageService.js', () => ({
+  createPageService: (...args) => mockCreatePageService(...args),
+}));
+
+vi.mock('../services/ghostServiceImproved.js', () => ({
+  updatePost: (...args) => mockUpdatePost(...args),
+  deletePost: (...args) => mockDeletePost(...args),
+  searchPosts: (...args) => mockSearchPosts(...args),
+  getPages: (...args) => mockGetPages(...args),
+  getPage: (...args) => mockGetPage(...args),
+  updatePage: (...args) => mockUpdatePage(...args),
+  deletePage: (...args) => mockDeletePage(...args),
+  searchPages: (...args) => mockSearchPages(...args),
+}));
+
+vi.mock('../services/imageProcessingService.js', () => ({
+  processImage: (...args) => mockProcessImage(...args),
+}));
+
+vi.mock('../utils/urlValidator.js', () => ({
+  validateImageUrl: (...args) => mockValidateImageUrl(...args),
+  createSecureAxiosConfig: (...args) => mockCreateSecureAxiosConfig(...args),
+}));
+
+// Mock axios
+const mockAxios = vi.fn();
+vi.mock('axios', () => ({
+  default: (...args) => mockAxios(...args),
+}));
+
+// Mock fs
+const mockUnlink = vi.fn((path, cb) => cb(null));
+const mockCreateWriteStream = vi.fn();
+vi.mock('fs', () => ({
+  default: {
+    unlink: (...args) => mockUnlink(...args),
+    createWriteStream: (...args) => mockCreateWriteStream(...args),
+  },
+}));
+
+// Mock os
+vi.mock('os', () => ({
+  default: { tmpdir: vi.fn().mockReturnValue('/tmp') },
+}));
+
+// Mock path
+vi.mock('path', async () => {
+  const actual = await vi.importActual('path');
+  return {
+    default: actual,
+    ...actual,
+  };
+});
+
+describe('mcp_server_improved - ghost_get_pages tool', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // Import the module to register tools (only first time)
+    if (mockTools.size === 0) {
+      await import('../mcp_server_improved.js');
+    }
+  });
+
+  it('should register ghost_get_pages tool', () => {
+    expect(mockTools.has('ghost_get_pages')).toBe(true);
+  });
+
+  it('should have correct schema with all optional parameters', () => {
+    const tool = mockTools.get('ghost_get_pages');
+    expect(tool).toBeDefined();
+    expect(tool.description).toContain('pages');
+    expect(tool.schema).toBeDefined();
+    expect(tool.schema.limit).toBeDefined();
+    expect(tool.schema.page).toBeDefined();
+    expect(tool.schema.status).toBeDefined();
+    expect(tool.schema.include).toBeDefined();
+    expect(tool.schema.filter).toBeDefined();
+    expect(tool.schema.order).toBeDefined();
+  });
+
+  it('should retrieve pages with default options', async () => {
+    const mockPages = [
+      { id: '1', title: 'About Us', slug: 'about-us', status: 'published' },
+      { id: '2', title: 'Contact', slug: 'contact', status: 'draft' },
+    ];
+    mockGetPages.mockResolvedValue(mockPages);
+
+    const tool = mockTools.get('ghost_get_pages');
+    const result = await tool.handler({});
+
+    expect(mockGetPages).toHaveBeenCalledWith({});
+    expect(result.content[0].text).toContain('About Us');
+    expect(result.content[0].text).toContain('Contact');
+  });
+
+  it('should pass limit and page parameters', async () => {
+    const mockPages = [{ id: '1', title: 'Page 1', slug: 'page-1' }];
+    mockGetPages.mockResolvedValue(mockPages);
+
+    const tool = mockTools.get('ghost_get_pages');
+    await tool.handler({ limit: 10, page: 2 });
+
+    expect(mockGetPages).toHaveBeenCalledWith({ limit: 10, page: 2 });
+  });
+
+  it('should validate limit is between 1 and 100', () => {
+    const tool = mockTools.get('ghost_get_pages');
+    const schema = tool.schema;
+
+    expect(schema.limit).toBeDefined();
+    expect(() => schema.limit.parse(0)).toThrow();
+    expect(() => schema.limit.parse(101)).toThrow();
+    expect(schema.limit.parse(50)).toBe(50);
+  });
+
+  it('should pass status filter', async () => {
+    const mockPages = [{ id: '1', title: 'Published Page', status: 'published' }];
+    mockGetPages.mockResolvedValue(mockPages);
+
+    const tool = mockTools.get('ghost_get_pages');
+    await tool.handler({ status: 'published' });
+
+    expect(mockGetPages).toHaveBeenCalledWith({ status: 'published' });
+  });
+
+  it('should handle errors gracefully', async () => {
+    mockGetPages.mockRejectedValue(new Error('API error'));
+
+    const tool = mockTools.get('ghost_get_pages');
+    const result = await tool.handler({});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Error retrieving pages');
+  });
+});
+
+describe('mcp_server_improved - ghost_get_page tool', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    if (mockTools.size === 0) {
+      await import('../mcp_server_improved.js');
+    }
+  });
+
+  it('should register ghost_get_page tool', () => {
+    expect(mockTools.has('ghost_get_page')).toBe(true);
+  });
+
+  it('should have correct schema with id and slug options', () => {
+    const tool = mockTools.get('ghost_get_page');
+    expect(tool).toBeDefined();
+    expect(tool.schema.id).toBeDefined();
+    expect(tool.schema.slug).toBeDefined();
+    expect(tool.schema.include).toBeDefined();
+  });
+
+  it('should retrieve page by ID', async () => {
+    const mockPage = { id: 'page-123', title: 'About Us', slug: 'about-us' };
+    mockGetPage.mockResolvedValue(mockPage);
+
+    const tool = mockTools.get('ghost_get_page');
+    const result = await tool.handler({ id: 'page-123' });
+
+    expect(mockGetPage).toHaveBeenCalledWith('page-123', {});
+    expect(result.content[0].text).toContain('About Us');
+  });
+
+  it('should retrieve page by slug', async () => {
+    const mockPage = { id: 'page-123', title: 'About Us', slug: 'about-us' };
+    mockGetPage.mockResolvedValue(mockPage);
+
+    const tool = mockTools.get('ghost_get_page');
+    const result = await tool.handler({ slug: 'about-us' });
+
+    expect(mockGetPage).toHaveBeenCalledWith('slug/about-us', {});
+    expect(result.content[0].text).toContain('About Us');
+  });
+
+  it('should require either id or slug', async () => {
+    const tool = mockTools.get('ghost_get_page');
+    const result = await tool.handler({});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Either id or slug is required');
+  });
+
+  it('should handle errors gracefully', async () => {
+    mockGetPage.mockRejectedValue(new Error('Page not found'));
+
+    const tool = mockTools.get('ghost_get_page');
+    const result = await tool.handler({ id: 'nonexistent' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Error retrieving page');
+  });
+});
+
+describe('mcp_server_improved - ghost_create_page tool', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    if (mockTools.size === 0) {
+      await import('../mcp_server_improved.js');
+    }
+  });
+
+  it('should register ghost_create_page tool', () => {
+    expect(mockTools.has('ghost_create_page')).toBe(true);
+  });
+
+  it('should have correct schema with required and optional fields', () => {
+    const tool = mockTools.get('ghost_create_page');
+    expect(tool).toBeDefined();
+    expect(tool.description).toContain('NOT support tags');
+    expect(tool.schema.title).toBeDefined();
+    expect(tool.schema.html).toBeDefined();
+    expect(tool.schema.status).toBeDefined();
+    expect(tool.schema.feature_image).toBeDefined();
+    expect(tool.schema.meta_title).toBeDefined();
+    expect(tool.schema.meta_description).toBeDefined();
+    // Should NOT have tags
+    expect(tool.schema.tags).toBeUndefined();
+  });
+
+  it('should create page with minimal input', async () => {
+    const createdPage = { id: 'page-123', title: 'New Page', status: 'draft' };
+    mockCreatePageService.mockResolvedValue(createdPage);
+
+    const tool = mockTools.get('ghost_create_page');
+    const result = await tool.handler({ title: 'New Page', html: '<p>Content</p>' });
+
+    expect(mockCreatePageService).toHaveBeenCalledWith({
+      title: 'New Page',
+      html: '<p>Content</p>',
+    });
+    expect(result.content[0].text).toContain('New Page');
+  });
+
+  it('should create page with all optional fields', async () => {
+    const fullInput = {
+      title: 'Complete Page',
+      html: '<p>Content</p>',
+      status: 'published',
+      custom_excerpt: 'Excerpt',
+      feature_image: 'https://example.com/image.jpg',
+      feature_image_alt: 'Alt text',
+      feature_image_caption: 'Caption',
+      meta_title: 'SEO Title',
+      meta_description: 'SEO Description',
+    };
+    const createdPage = { id: 'page-123', ...fullInput };
+    mockCreatePageService.mockResolvedValue(createdPage);
+
+    const tool = mockTools.get('ghost_create_page');
+    const result = await tool.handler(fullInput);
+
+    expect(mockCreatePageService).toHaveBeenCalledWith(fullInput);
+    expect(result.content[0].text).toContain('Complete Page');
+  });
+
+  it('should handle errors gracefully', async () => {
+    mockCreatePageService.mockRejectedValue(new Error('Invalid input'));
+
+    const tool = mockTools.get('ghost_create_page');
+    const result = await tool.handler({ title: 'Test', html: '<p>Content</p>' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Error creating page');
+  });
+});
+
+describe('mcp_server_improved - ghost_update_page tool', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    if (mockTools.size === 0) {
+      await import('../mcp_server_improved.js');
+    }
+  });
+
+  it('should register ghost_update_page tool', () => {
+    expect(mockTools.has('ghost_update_page')).toBe(true);
+  });
+
+  it('should have correct schema with id required and other fields optional', () => {
+    const tool = mockTools.get('ghost_update_page');
+    expect(tool).toBeDefined();
+    expect(tool.description).toContain('NOT support tags');
+    expect(tool.schema.id).toBeDefined();
+    expect(tool.schema.title).toBeDefined();
+    expect(tool.schema.html).toBeDefined();
+    expect(tool.schema.status).toBeDefined();
+    // Should NOT have tags
+    expect(tool.schema.tags).toBeUndefined();
+  });
+
+  it('should update page with new title', async () => {
+    const updatedPage = { id: 'page-123', title: 'Updated Title' };
+    mockUpdatePage.mockResolvedValue(updatedPage);
+
+    const tool = mockTools.get('ghost_update_page');
+    const result = await tool.handler({ id: 'page-123', title: 'Updated Title' });
+
+    expect(mockUpdatePage).toHaveBeenCalledWith('page-123', { title: 'Updated Title' });
+    expect(result.content[0].text).toContain('Updated Title');
+  });
+
+  it('should update page with multiple fields', async () => {
+    const updatedPage = { id: 'page-123', title: 'New Title', status: 'published' };
+    mockUpdatePage.mockResolvedValue(updatedPage);
+
+    const tool = mockTools.get('ghost_update_page');
+    const result = await tool.handler({
+      id: 'page-123',
+      title: 'New Title',
+      status: 'published',
+      html: '<p>Updated content</p>',
+    });
+
+    expect(mockUpdatePage).toHaveBeenCalledWith('page-123', {
+      title: 'New Title',
+      status: 'published',
+      html: '<p>Updated content</p>',
+    });
+    expect(result.content[0].text).toContain('New Title');
+  });
+
+  it('should handle errors gracefully', async () => {
+    mockUpdatePage.mockRejectedValue(new Error('Page not found'));
+
+    const tool = mockTools.get('ghost_update_page');
+    const result = await tool.handler({ id: 'nonexistent', title: 'Test' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Error updating page');
+  });
+});
+
+describe('mcp_server_improved - ghost_delete_page tool', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    if (mockTools.size === 0) {
+      await import('../mcp_server_improved.js');
+    }
+  });
+
+  it('should register ghost_delete_page tool', () => {
+    expect(mockTools.has('ghost_delete_page')).toBe(true);
+  });
+
+  it('should have correct schema with id required', () => {
+    const tool = mockTools.get('ghost_delete_page');
+    expect(tool).toBeDefined();
+    expect(tool.schema.id).toBeDefined();
+    expect(tool.description).toContain('permanent');
+  });
+
+  it('should delete page by ID', async () => {
+    mockDeletePage.mockResolvedValue({ id: 'page-123' });
+
+    const tool = mockTools.get('ghost_delete_page');
+    const result = await tool.handler({ id: 'page-123' });
+
+    expect(mockDeletePage).toHaveBeenCalledWith('page-123');
+    expect(result.content[0].text).toContain('successfully deleted');
+  });
+
+  it('should handle errors gracefully', async () => {
+    mockDeletePage.mockRejectedValue(new Error('Page not found'));
+
+    const tool = mockTools.get('ghost_delete_page');
+    const result = await tool.handler({ id: 'nonexistent' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Error deleting page');
+  });
+});
+
+describe('mcp_server_improved - ghost_search_pages tool', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    if (mockTools.size === 0) {
+      await import('../mcp_server_improved.js');
+    }
+  });
+
+  it('should register ghost_search_pages tool', () => {
+    expect(mockTools.has('ghost_search_pages')).toBe(true);
+  });
+
+  it('should have correct schema with query required', () => {
+    const tool = mockTools.get('ghost_search_pages');
+    expect(tool).toBeDefined();
+    expect(tool.schema.query).toBeDefined();
+    expect(tool.schema.status).toBeDefined();
+    expect(tool.schema.limit).toBeDefined();
+  });
+
+  it('should search pages with query', async () => {
+    const mockPages = [{ id: '1', title: 'About Us', slug: 'about-us' }];
+    mockSearchPages.mockResolvedValue(mockPages);
+
+    const tool = mockTools.get('ghost_search_pages');
+    const result = await tool.handler({ query: 'about' });
+
+    expect(mockSearchPages).toHaveBeenCalledWith('about', {});
+    expect(result.content[0].text).toContain('About Us');
+  });
+
+  it('should pass status filter', async () => {
+    const mockPages = [{ id: '1', title: 'Published Page' }];
+    mockSearchPages.mockResolvedValue(mockPages);
+
+    const tool = mockTools.get('ghost_search_pages');
+    await tool.handler({ query: 'test', status: 'published' });
+
+    expect(mockSearchPages).toHaveBeenCalledWith('test', { status: 'published' });
+  });
+
+  it('should pass limit option', async () => {
+    const mockPages = [];
+    mockSearchPages.mockResolvedValue(mockPages);
+
+    const tool = mockTools.get('ghost_search_pages');
+    await tool.handler({ query: 'test', limit: 5 });
+
+    expect(mockSearchPages).toHaveBeenCalledWith('test', { limit: 5 });
+  });
+
+  it('should validate limit is between 1 and 50', () => {
+    const tool = mockTools.get('ghost_search_pages');
+    const schema = tool.schema;
+
+    expect(schema.limit).toBeDefined();
+    expect(() => schema.limit.parse(0)).toThrow();
+    expect(() => schema.limit.parse(51)).toThrow();
+    expect(schema.limit.parse(25)).toBe(25);
+  });
+
+  it('should handle errors gracefully', async () => {
+    mockSearchPages.mockRejectedValue(new Error('Search failed'));
+
+    const tool = mockTools.get('ghost_search_pages');
+    const result = await tool.handler({ query: 'test' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Error searching pages');
+  });
+});

--- a/src/services/__tests__/ghostServiceImproved.pages.test.js
+++ b/src/services/__tests__/ghostServiceImproved.pages.test.js
@@ -1,0 +1,561 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMockContextLogger } from '../../__tests__/helpers/mockLogger.js';
+import { mockDotenv } from '../../__tests__/helpers/testUtils.js';
+
+// Mock the Ghost Admin API with pages support
+vi.mock('@tryghost/admin-api', () => ({
+  default: vi.fn(function () {
+    return {
+      posts: {
+        add: vi.fn(),
+        browse: vi.fn(),
+        read: vi.fn(),
+        edit: vi.fn(),
+        delete: vi.fn(),
+      },
+      pages: {
+        add: vi.fn(),
+        browse: vi.fn(),
+        read: vi.fn(),
+        edit: vi.fn(),
+        delete: vi.fn(),
+      },
+      tags: {
+        add: vi.fn(),
+        browse: vi.fn(),
+        read: vi.fn(),
+        edit: vi.fn(),
+        delete: vi.fn(),
+      },
+      site: {
+        read: vi.fn(),
+      },
+      images: {
+        upload: vi.fn(),
+      },
+    };
+  }),
+}));
+
+// Mock dotenv
+vi.mock('dotenv', () => mockDotenv());
+
+// Mock logger
+vi.mock('../../utils/logger.js', () => ({
+  createContextLogger: createMockContextLogger(),
+}));
+
+// Mock fs for validateImagePath (not needed for pages but part of validators)
+vi.mock('fs/promises', () => ({
+  default: {
+    access: vi.fn(),
+  },
+}));
+
+// Import after setting up mocks
+import {
+  createPage,
+  updatePage,
+  deletePage,
+  getPage,
+  getPages,
+  searchPages,
+  api,
+  validators,
+} from '../ghostServiceImproved.js';
+
+describe('ghostServiceImproved - Pages', () => {
+  beforeEach(() => {
+    // Reset all mocks before each test
+    vi.clearAllMocks();
+  });
+
+  describe('validators.validatePageData', () => {
+    it('should validate required title field', () => {
+      expect(() => validators.validatePageData({})).toThrow('Page validation failed');
+      expect(() => validators.validatePageData({ title: '' })).toThrow('Page validation failed');
+      expect(() => validators.validatePageData({ title: '   ' })).toThrow('Page validation failed');
+    });
+
+    it('should validate required content field (html or mobiledoc)', () => {
+      expect(() => validators.validatePageData({ title: 'Test Page' })).toThrow(
+        'Page validation failed'
+      );
+    });
+
+    it('should accept valid html content', () => {
+      expect(() =>
+        validators.validatePageData({ title: 'Test Page', html: '<p>Content</p>' })
+      ).not.toThrow();
+    });
+
+    it('should accept valid mobiledoc content', () => {
+      expect(() =>
+        validators.validatePageData({ title: 'Test Page', mobiledoc: '{"version":"0.3.1"}' })
+      ).not.toThrow();
+    });
+
+    it('should validate status enum values', () => {
+      expect(() =>
+        validators.validatePageData({ title: 'Test', html: '<p>Content</p>', status: 'invalid' })
+      ).toThrow('Page validation failed');
+
+      // Valid status values should not throw
+      expect(() =>
+        validators.validatePageData({ title: 'Test', html: '<p>Content</p>', status: 'draft' })
+      ).not.toThrow();
+      expect(() =>
+        validators.validatePageData({ title: 'Test', html: '<p>Content</p>', status: 'published' })
+      ).not.toThrow();
+      // Note: scheduled without published_at will throw, tested separately
+    });
+
+    it('should require published_at when status is scheduled', () => {
+      expect(() =>
+        validators.validatePageData({ title: 'Test', html: '<p>Content</p>', status: 'scheduled' })
+      ).toThrow('Page validation failed');
+    });
+
+    it('should validate published_at date format', () => {
+      expect(() =>
+        validators.validatePageData({
+          title: 'Test',
+          html: '<p>Content</p>',
+          published_at: 'invalid-date',
+        })
+      ).toThrow('Page validation failed');
+    });
+
+    it('should require future date for scheduled pages', () => {
+      const pastDate = new Date(Date.now() - 86400000).toISOString(); // Yesterday
+      expect(() =>
+        validators.validatePageData({
+          title: 'Test',
+          html: '<p>Content</p>',
+          status: 'scheduled',
+          published_at: pastDate,
+        })
+      ).toThrow('Page validation failed');
+    });
+
+    it('should accept future date for scheduled pages', () => {
+      const futureDate = new Date(Date.now() + 86400000).toISOString(); // Tomorrow
+      expect(() =>
+        validators.validatePageData({
+          title: 'Test',
+          html: '<p>Content</p>',
+          status: 'scheduled',
+          published_at: futureDate,
+        })
+      ).not.toThrow();
+    });
+
+    it('should NOT validate tags field (pages do not support tags)', () => {
+      // This test ensures that tags are not part of page validation
+      // Pages should work with or without tags field (it will be ignored by Ghost API)
+      expect(() =>
+        validators.validatePageData({
+          title: 'Test',
+          html: '<p>Content</p>',
+          tags: ['tag1', 'tag2'],
+        })
+      ).not.toThrow();
+    });
+  });
+
+  describe('createPage', () => {
+    it('should throw validation error when title is missing', async () => {
+      await expect(createPage({ html: '<p>Content</p>' })).rejects.toThrow('Page validation');
+    });
+
+    it('should throw validation error when content is missing', async () => {
+      await expect(createPage({ title: 'Test Page' })).rejects.toThrow('Page validation');
+    });
+
+    it('should create page with minimal valid data', async () => {
+      const pageData = { title: 'Test Page', html: '<p>Content</p>' };
+      const expectedPage = { id: '1', ...pageData, status: 'draft' };
+      api.pages.add.mockResolvedValue(expectedPage);
+
+      const result = await createPage(pageData);
+
+      expect(result).toEqual(expectedPage);
+      expect(api.pages.add).toHaveBeenCalledWith(
+        { status: 'draft', ...pageData },
+        { source: 'html' }
+      );
+    });
+
+    it('should set default status to draft when not provided', async () => {
+      const pageData = { title: 'Test Page', html: '<p>Content</p>' };
+      api.pages.add.mockResolvedValue({ id: '1', ...pageData, status: 'draft' });
+
+      await createPage(pageData);
+
+      expect(api.pages.add).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'draft' }),
+        expect.any(Object)
+      );
+    });
+
+    it('should create page with all optional fields', async () => {
+      const pageData = {
+        title: 'Test Page',
+        html: '<p>Content</p>',
+        status: 'published',
+        custom_excerpt: 'Test excerpt',
+        feature_image: 'https://example.com/image.jpg',
+        feature_image_alt: 'Alt text',
+        feature_image_caption: 'Caption',
+        meta_title: 'Meta Title',
+        meta_description: 'Meta description',
+      };
+      const expectedPage = { id: '1', ...pageData };
+      api.pages.add.mockResolvedValue(expectedPage);
+
+      const result = await createPage(pageData);
+
+      expect(result).toEqual(expectedPage);
+      expect(api.pages.add).toHaveBeenCalledWith(pageData, { source: 'html' });
+    });
+
+    it('should sanitize HTML content', async () => {
+      const pageData = {
+        title: 'Test Page',
+        html: '<p>Safe content</p><script>alert("xss")</script>',
+      };
+      api.pages.add.mockResolvedValue({ id: '1', ...pageData });
+
+      await createPage(pageData);
+
+      // Verify that the HTML was sanitized (script tags removed)
+      const calledWith = api.pages.add.mock.calls[0][0];
+      expect(calledWith.html).not.toContain('<script>');
+      expect(calledWith.html).toContain('<p>Safe content</p>');
+    });
+
+    it('should handle Ghost API validation errors (422)', async () => {
+      const error422 = new Error('Validation failed');
+      error422.response = { status: 422 };
+      api.pages.add.mockRejectedValue(error422);
+
+      await expect(createPage({ title: 'Test', html: '<p>Content</p>' })).rejects.toThrow(
+        'Page creation failed due to validation errors'
+      );
+    });
+
+    it('should NOT include tags in page creation (pages do not support tags)', async () => {
+      const pageData = {
+        title: 'Test Page',
+        html: '<p>Content</p>',
+        tags: ['tag1', 'tag2'], // This should be ignored
+      };
+      api.pages.add.mockResolvedValue({ id: '1', title: 'Test Page', html: '<p>Content</p>' });
+
+      await createPage(pageData);
+
+      // Verify that tags were passed through (Ghost API will ignore them for pages)
+      const calledWith = api.pages.add.mock.calls[0][0];
+      expect(calledWith).toMatchObject({ title: 'Test Page', html: expect.any(String) });
+    });
+  });
+
+  describe('updatePage', () => {
+    it('should throw error when page ID is missing', async () => {
+      await expect(updatePage(null, { title: 'Updated' })).rejects.toThrow('Page ID is required');
+      await expect(updatePage('', { title: 'Updated' })).rejects.toThrow('Page ID is required');
+    });
+
+    it('should update page with valid data', async () => {
+      const pageId = 'page-123';
+      const existingPage = {
+        id: pageId,
+        title: 'Original Title',
+        html: '<p>Original content</p>',
+        updated_at: '2024-01-01T00:00:00.000Z',
+      };
+      const updateData = { title: 'Updated Title' };
+      const expectedPage = { ...existingPage, ...updateData };
+
+      api.pages.read.mockResolvedValue(existingPage);
+      api.pages.edit.mockResolvedValue(expectedPage);
+
+      const result = await updatePage(pageId, updateData);
+
+      expect(result).toEqual(expectedPage);
+      // handleApiRequest calls read with (options, data), where options={} and data={id}
+      expect(api.pages.read).toHaveBeenCalledWith({}, { id: pageId });
+      expect(api.pages.edit).toHaveBeenCalledWith(
+        { ...existingPage, ...updateData },
+        { id: pageId }
+      );
+    });
+
+    it('should handle page not found (404)', async () => {
+      const error404 = new Error('Page not found');
+      error404.response = { status: 404 };
+      api.pages.read.mockRejectedValue(error404);
+
+      await expect(updatePage('nonexistent-id', { title: 'Updated' })).rejects.toThrow(
+        'Page not found'
+      );
+    });
+
+    it('should preserve updated_at timestamp for conflict resolution', async () => {
+      const pageId = 'page-123';
+      const existingPage = {
+        id: pageId,
+        title: 'Original',
+        updated_at: '2024-01-01T00:00:00.000Z',
+      };
+      api.pages.read.mockResolvedValue(existingPage);
+      api.pages.edit.mockResolvedValue({ ...existingPage, title: 'Updated' });
+
+      await updatePage(pageId, { title: 'Updated' });
+
+      const editCall = api.pages.edit.mock.calls[0][0];
+      expect(editCall.updated_at).toBe('2024-01-01T00:00:00.000Z');
+    });
+
+    it('should sanitize HTML content in updates', async () => {
+      const pageId = 'page-123';
+      const existingPage = { id: pageId, title: 'Test', updated_at: '2024-01-01T00:00:00.000Z' };
+      api.pages.read.mockResolvedValue(existingPage);
+      api.pages.edit.mockResolvedValue({ ...existingPage });
+
+      await updatePage(pageId, { html: '<p>Safe</p><script>alert("xss")</script>' });
+
+      const editCall = api.pages.edit.mock.calls[0][0];
+      expect(editCall.html).not.toContain('<script>');
+    });
+  });
+
+  describe('deletePage', () => {
+    it('should throw error when page ID is missing', async () => {
+      await expect(deletePage(null)).rejects.toThrow('Page ID is required');
+      await expect(deletePage('')).rejects.toThrow('Page ID is required');
+    });
+
+    it('should delete page successfully', async () => {
+      const pageId = 'page-123';
+      api.pages.delete.mockResolvedValue({ id: pageId });
+
+      const result = await deletePage(pageId);
+
+      expect(result).toEqual({ id: pageId });
+      // handleApiRequest calls delete with (data.id || data, options)
+      expect(api.pages.delete).toHaveBeenCalledWith(pageId, {});
+    });
+
+    it('should handle page not found (404)', async () => {
+      const error404 = new Error('Page not found');
+      error404.response = { status: 404 };
+      api.pages.delete.mockRejectedValue(error404);
+
+      await expect(deletePage('nonexistent-id')).rejects.toThrow('Page not found');
+    });
+  });
+
+  describe('getPage', () => {
+    it('should throw error when page ID is missing', async () => {
+      await expect(getPage(null)).rejects.toThrow('Page ID is required');
+      await expect(getPage('')).rejects.toThrow('Page ID is required');
+    });
+
+    it('should get page by ID', async () => {
+      const pageId = 'page-123';
+      const expectedPage = { id: pageId, title: 'Test Page', html: '<p>Content</p>' };
+      api.pages.read.mockResolvedValue(expectedPage);
+
+      const result = await getPage(pageId);
+
+      expect(result).toEqual(expectedPage);
+      // handleApiRequest calls read with (options, data)
+      expect(api.pages.read).toHaveBeenCalledWith({}, { id: pageId });
+    });
+
+    it('should get page by slug', async () => {
+      const slug = 'test-page';
+      const expectedPage = { id: 'page-123', slug, title: 'Test Page' };
+      api.pages.read.mockResolvedValue(expectedPage);
+
+      const result = await getPage(`slug/${slug}`);
+
+      expect(result).toEqual(expectedPage);
+      expect(api.pages.read).toHaveBeenCalledWith({}, { id: `slug/${slug}` });
+    });
+
+    it('should pass options to API (include, etc.)', async () => {
+      const pageId = 'page-123';
+      const options = { include: 'authors' };
+      api.pages.read.mockResolvedValue({ id: pageId });
+
+      await getPage(pageId, options);
+
+      expect(api.pages.read).toHaveBeenCalledWith(options, { id: pageId });
+    });
+
+    it('should handle page not found (404)', async () => {
+      const error404 = new Error('Page not found');
+      error404.response = { status: 404 };
+      api.pages.read.mockRejectedValue(error404);
+
+      await expect(getPage('nonexistent-id')).rejects.toThrow('Page not found');
+    });
+  });
+
+  describe('getPages', () => {
+    it('should get all pages with default options', async () => {
+      const expectedPages = [
+        { id: '1', title: 'Page 1' },
+        { id: '2', title: 'Page 2' },
+      ];
+      api.pages.browse.mockResolvedValue(expectedPages);
+
+      const result = await getPages();
+
+      expect(result).toEqual(expectedPages);
+      // getPages applies defaults (limit: 15, include: 'authors')
+      expect(api.pages.browse).toHaveBeenCalledWith({ limit: 15, include: 'authors' }, {});
+    });
+
+    it('should pass pagination options', async () => {
+      const options = { limit: 10, page: 2 };
+      api.pages.browse.mockResolvedValue([]);
+
+      await getPages(options);
+
+      // getPages merges options with defaults
+      expect(api.pages.browse).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 10, page: 2, include: 'authors' }),
+        {}
+      );
+    });
+
+    it('should pass status filter', async () => {
+      const options = { status: 'published' };
+      api.pages.browse.mockResolvedValue([]);
+
+      await getPages(options);
+
+      expect(api.pages.browse).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'published', limit: 15, include: 'authors' }),
+        {}
+      );
+    });
+
+    it('should pass include options', async () => {
+      const options = { include: 'authors,tags' };
+      api.pages.browse.mockResolvedValue([]);
+
+      await getPages(options);
+
+      expect(api.pages.browse).toHaveBeenCalledWith(
+        expect.objectContaining({ include: 'authors,tags', limit: 15 }),
+        {}
+      );
+    });
+
+    it('should pass NQL filter', async () => {
+      const options = { filter: 'featured:true' };
+      api.pages.browse.mockResolvedValue([]);
+
+      await getPages(options);
+
+      expect(api.pages.browse).toHaveBeenCalledWith(
+        expect.objectContaining({ filter: 'featured:true', limit: 15, include: 'authors' }),
+        {}
+      );
+    });
+
+    it('should pass order/sort options', async () => {
+      const options = { order: 'published_at DESC' };
+      api.pages.browse.mockResolvedValue([]);
+
+      await getPages(options);
+
+      expect(api.pages.browse).toHaveBeenCalledWith(
+        expect.objectContaining({ order: 'published_at DESC', limit: 15, include: 'authors' }),
+        {}
+      );
+    });
+  });
+
+  describe('searchPages', () => {
+    it('should throw error when query is missing', async () => {
+      await expect(searchPages(null)).rejects.toThrow('Search query is required');
+      await expect(searchPages('')).rejects.toThrow('Search query is required');
+    });
+
+    it('should search pages with query', async () => {
+      const query = 'test search';
+      const expectedPages = [{ id: '1', title: 'Test Page' }];
+      api.pages.browse.mockResolvedValue(expectedPages);
+
+      const result = await searchPages(query);
+
+      expect(result).toEqual(expectedPages);
+      // Verify NQL filter was created with escaped query
+      const browseCall = api.pages.browse.mock.calls[0][0];
+      expect(browseCall.filter).toContain('title:~');
+      expect(browseCall.filter).toContain('test search');
+    });
+
+    it('should sanitize query to prevent NQL injection', async () => {
+      const maliciousQuery = "test'; DELETE FROM pages; --";
+      api.pages.browse.mockResolvedValue([]);
+
+      await searchPages(maliciousQuery);
+
+      const browseCall = api.pages.browse.mock.calls[0][0];
+      // Verify that backslashes and quotes are escaped
+      expect(browseCall.filter).toContain("\\'");
+    });
+
+    it('should escape backslashes in query', async () => {
+      const query = 'test\\path';
+      api.pages.browse.mockResolvedValue([]);
+
+      await searchPages(query);
+
+      const browseCall = api.pages.browse.mock.calls[0][0];
+      expect(browseCall.filter).toContain('\\\\');
+    });
+
+    it('should pass status filter option', async () => {
+      const query = 'test';
+      const options = { status: 'published' };
+      api.pages.browse.mockResolvedValue([]);
+
+      await searchPages(query, options);
+
+      const browseCall = api.pages.browse.mock.calls[0][0];
+      expect(browseCall.filter).toContain('status:published');
+    });
+
+    it('should pass limit option', async () => {
+      const query = 'test';
+      const options = { limit: 5 };
+      api.pages.browse.mockResolvedValue([]);
+
+      await searchPages(query, options);
+
+      const browseCall = api.pages.browse.mock.calls[0][0];
+      expect(browseCall.limit).toBe(5);
+    });
+
+    it('should combine query and status in NQL filter', async () => {
+      const query = 'about';
+      const options = { status: 'published' };
+      api.pages.browse.mockResolvedValue([]);
+
+      await searchPages(query, options);
+
+      const browseCall = api.pages.browse.mock.calls[0][0];
+      expect(browseCall.filter).toContain('title:~');
+      expect(browseCall.filter).toContain('about');
+      expect(browseCall.filter).toContain('status:published');
+      expect(browseCall.filter).toContain('+');
+    });
+  });
+});

--- a/src/services/__tests__/pageService.test.js
+++ b/src/services/__tests__/pageService.test.js
@@ -1,0 +1,400 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mockDotenv } from '../../__tests__/helpers/testUtils.js';
+import { createMockContextLogger } from '../../__tests__/helpers/mockLogger.js';
+
+// Mock dotenv
+vi.mock('dotenv', () => mockDotenv());
+
+// Mock logger
+vi.mock('../../utils/logger.js', () => ({
+  createContextLogger: createMockContextLogger(),
+}));
+
+// Mock ghostServiceImproved functions
+vi.mock('../ghostServiceImproved.js', () => ({
+  createPage: vi.fn(),
+}));
+
+// Import after mocks are set up
+import { createPageService } from '../pageService.js';
+import { createPage } from '../ghostServiceImproved.js';
+
+describe('pageService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('createPageService - validation', () => {
+    it('should accept valid input and create a page', async () => {
+      const validInput = {
+        title: 'Test Page',
+        html: '<p>Test content</p>',
+      };
+      const expectedPage = { id: '1', title: 'Test Page', status: 'draft' };
+      createPage.mockResolvedValue(expectedPage);
+
+      const result = await createPageService(validInput);
+
+      expect(result).toEqual(expectedPage);
+      expect(createPage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Test Page',
+          html: '<p>Test content</p>',
+          status: 'draft',
+        })
+      );
+    });
+
+    it('should reject input with missing title', async () => {
+      const invalidInput = {
+        html: '<p>Test content</p>',
+      };
+
+      await expect(createPageService(invalidInput)).rejects.toThrow(
+        'Invalid page input: "title" is required'
+      );
+      expect(createPage).not.toHaveBeenCalled();
+    });
+
+    it('should reject input with missing html', async () => {
+      const invalidInput = {
+        title: 'Test Page',
+      };
+
+      await expect(createPageService(invalidInput)).rejects.toThrow(
+        'Invalid page input: "html" is required'
+      );
+      expect(createPage).not.toHaveBeenCalled();
+    });
+
+    it('should reject input with invalid status', async () => {
+      const invalidInput = {
+        title: 'Test Page',
+        html: '<p>Content</p>',
+        status: 'invalid-status',
+      };
+
+      await expect(createPageService(invalidInput)).rejects.toThrow(
+        'Invalid page input: "status" must be one of [draft, published, scheduled]'
+      );
+      expect(createPage).not.toHaveBeenCalled();
+    });
+
+    it('should accept valid status values', async () => {
+      const statuses = ['draft', 'published', 'scheduled'];
+      createPage.mockResolvedValue({ id: '1', title: 'Test' });
+
+      for (const status of statuses) {
+        const input = {
+          title: 'Test Page',
+          html: '<p>Content</p>',
+          status,
+        };
+
+        await createPageService(input);
+
+        expect(createPage).toHaveBeenCalledWith(expect.objectContaining({ status }));
+        vi.clearAllMocks();
+      }
+    });
+
+    it('should reject tags field (pages do not support tags)', async () => {
+      const invalidInput = {
+        title: 'Test Page',
+        html: '<p>Content</p>',
+        tags: ['tag1', 'tag2'],
+      };
+
+      // Tags field should cause validation error since it's not in the schema
+      await expect(createPageService(invalidInput)).rejects.toThrow('Invalid page input:');
+      expect(createPage).not.toHaveBeenCalled();
+    });
+
+    it('should validate feature_image is a valid URI', async () => {
+      const invalidInput = {
+        title: 'Test Page',
+        html: '<p>Content</p>',
+        feature_image: 'not-a-valid-url',
+      };
+
+      await expect(createPageService(invalidInput)).rejects.toThrow('Invalid page input:');
+      expect(createPage).not.toHaveBeenCalled();
+    });
+
+    it('should accept valid feature_image URI', async () => {
+      const validInput = {
+        title: 'Test Page',
+        html: '<p>Content</p>',
+        feature_image: 'https://example.com/image.jpg',
+      };
+      createPage.mockResolvedValue({ id: '1', title: 'Test' });
+
+      await createPageService(validInput);
+
+      expect(createPage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          feature_image: 'https://example.com/image.jpg',
+        })
+      );
+    });
+
+    it('should validate title max length', async () => {
+      const invalidInput = {
+        title: 'a'.repeat(256), // 256 chars exceeds max of 255
+        html: '<p>Content</p>',
+      };
+
+      await expect(createPageService(invalidInput)).rejects.toThrow('Invalid page input:');
+      expect(createPage).not.toHaveBeenCalled();
+    });
+
+    it('should validate custom_excerpt max length', async () => {
+      const invalidInput = {
+        title: 'Test Page',
+        html: '<p>Content</p>',
+        custom_excerpt: 'a'.repeat(501), // 501 chars exceeds max of 500
+      };
+
+      await expect(createPageService(invalidInput)).rejects.toThrow('Invalid page input:');
+      expect(createPage).not.toHaveBeenCalled();
+    });
+
+    it('should validate meta_title max length', async () => {
+      const invalidInput = {
+        title: 'Test Page',
+        html: '<p>Content</p>',
+        meta_title: 'a'.repeat(71), // 71 chars exceeds max of 70
+      };
+
+      await expect(createPageService(invalidInput)).rejects.toThrow('Invalid page input:');
+      expect(createPage).not.toHaveBeenCalled();
+    });
+
+    it('should validate meta_description max length', async () => {
+      const invalidInput = {
+        title: 'Test Page',
+        html: '<p>Content</p>',
+        meta_description: 'a'.repeat(161), // 161 chars exceeds max of 160
+      };
+
+      await expect(createPageService(invalidInput)).rejects.toThrow('Invalid page input:');
+      expect(createPage).not.toHaveBeenCalled();
+    });
+
+    it('should validate published_at is ISO date format', async () => {
+      const invalidInput = {
+        title: 'Test Page',
+        html: '<p>Content</p>',
+        published_at: 'invalid-date',
+      };
+
+      await expect(createPageService(invalidInput)).rejects.toThrow('Invalid page input:');
+      expect(createPage).not.toHaveBeenCalled();
+    });
+
+    it('should accept valid published_at ISO date', async () => {
+      const validInput = {
+        title: 'Test Page',
+        html: '<p>Content</p>',
+        published_at: '2024-12-31T12:00:00.000Z',
+      };
+      createPage.mockResolvedValue({ id: '1', title: 'Test' });
+
+      await createPageService(validInput);
+
+      expect(createPage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          published_at: '2024-12-31T12:00:00.000Z',
+        })
+      );
+    });
+  });
+
+  describe('createPageService - metadata generation', () => {
+    beforeEach(() => {
+      createPage.mockResolvedValue({ id: '1', title: 'Test' });
+    });
+
+    it('should default meta_title to title when not provided', async () => {
+      const input = {
+        title: 'My Page Title',
+        html: '<p>Content</p>',
+      };
+
+      await createPageService(input);
+
+      expect(createPage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          meta_title: 'My Page Title',
+        })
+      );
+    });
+
+    it('should use provided meta_title instead of defaulting', async () => {
+      const input = {
+        title: 'My Page Title',
+        html: '<p>Content</p>',
+        meta_title: 'Custom Meta Title',
+      };
+
+      await createPageService(input);
+
+      expect(createPage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          meta_title: 'Custom Meta Title',
+        })
+      );
+    });
+
+    it('should default meta_description to custom_excerpt when provided', async () => {
+      const input = {
+        title: 'Test Page',
+        html: '<p>Content</p>',
+        custom_excerpt: 'This is my custom excerpt',
+      };
+
+      await createPageService(input);
+
+      expect(createPage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          meta_description: 'This is my custom excerpt',
+        })
+      );
+    });
+
+    it('should generate meta_description from HTML when not provided', async () => {
+      const input = {
+        title: 'Test Page',
+        html: '<p>This is the page content that will be used for meta description.</p>',
+      };
+
+      await createPageService(input);
+
+      expect(createPage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          meta_description: expect.stringContaining('This is the page content'),
+        })
+      );
+    });
+
+    it('should use provided meta_description over custom_excerpt', async () => {
+      const input = {
+        title: 'Test Page',
+        html: '<p>Content</p>',
+        custom_excerpt: 'This is the excerpt',
+        meta_description: 'This is the explicit meta description',
+      };
+
+      await createPageService(input);
+
+      expect(createPage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          meta_description: 'This is the explicit meta description',
+        })
+      );
+    });
+
+    it('should strip HTML tags when generating meta_description', async () => {
+      const input = {
+        title: 'Test Page',
+        html: '<h1>Heading</h1><p><strong>Bold</strong> and <em>italic</em> text</p>',
+      };
+
+      await createPageService(input);
+
+      const calledWith = createPage.mock.calls[0][0];
+      expect(calledWith.meta_description).not.toContain('<');
+      expect(calledWith.meta_description).not.toContain('>');
+      expect(calledWith.meta_description).toContain('Heading');
+      expect(calledWith.meta_description).toContain('Bold');
+      expect(calledWith.meta_description).toContain('italic');
+    });
+
+    it('should truncate meta_description to 500 characters', async () => {
+      const longContent = 'a'.repeat(600);
+      const input = {
+        title: 'Test Page',
+        html: `<p>${longContent}</p>`,
+      };
+
+      await createPageService(input);
+
+      const calledWith = createPage.mock.calls[0][0];
+      expect(calledWith.meta_description.length).toBeLessThanOrEqual(500);
+      expect(calledWith.meta_description).toContain('...');
+    });
+
+    it('should handle empty HTML content gracefully', async () => {
+      const input = {
+        title: 'Test Page',
+        html: '',
+      };
+
+      // Empty html should fail validation
+      await expect(createPageService(input)).rejects.toThrow('Invalid page input:');
+    });
+  });
+
+  describe('createPageService - complete page creation', () => {
+    it('should create page with all optional fields', async () => {
+      const fullInput = {
+        title: 'Complete Page',
+        html: '<p>Full content</p>',
+        custom_excerpt: 'Page excerpt',
+        status: 'published',
+        published_at: '2024-12-31T12:00:00.000Z',
+        feature_image: 'https://example.com/image.jpg',
+        feature_image_alt: 'Alt text',
+        feature_image_caption: 'Image caption',
+        meta_title: 'SEO Title',
+        meta_description: 'SEO Description',
+      };
+      const expectedPage = { id: '1', ...fullInput };
+      createPage.mockResolvedValue(expectedPage);
+
+      const result = await createPageService(fullInput);
+
+      expect(result).toEqual(expectedPage);
+      expect(createPage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Complete Page',
+          html: '<p>Full content</p>',
+          custom_excerpt: 'Page excerpt',
+          status: 'published',
+          published_at: '2024-12-31T12:00:00.000Z',
+          feature_image: 'https://example.com/image.jpg',
+          feature_image_alt: 'Alt text',
+          feature_image_caption: 'Image caption',
+          meta_title: 'SEO Title',
+          meta_description: 'SEO Description',
+        })
+      );
+    });
+
+    it('should default status to draft when not provided', async () => {
+      const input = {
+        title: 'Test Page',
+        html: '<p>Content</p>',
+      };
+      createPage.mockResolvedValue({ id: '1', title: 'Test', status: 'draft' });
+
+      await createPageService(input);
+
+      expect(createPage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'draft',
+        })
+      );
+    });
+
+    it('should propagate errors from ghostServiceImproved', async () => {
+      const input = {
+        title: 'Test Page',
+        html: '<p>Content</p>',
+      };
+      createPage.mockRejectedValue(new Error('Ghost API error'));
+
+      await expect(createPageService(input)).rejects.toThrow('Ghost API error');
+    });
+  });
+});

--- a/src/services/pageService.js
+++ b/src/services/pageService.js
@@ -1,0 +1,121 @@
+import sanitizeHtml from 'sanitize-html';
+import Joi from 'joi';
+import { createContextLogger } from '../utils/logger.js';
+import { createPage as createGhostPage } from './ghostServiceImproved.js';
+
+/**
+ * Helper to generate a simple meta description from HTML content.
+ * Uses sanitize-html to safely strip HTML tags and truncates.
+ * @param {string} htmlContent - The HTML content of the page.
+ * @param {number} maxLength - The maximum length of the description.
+ * @returns {string} A plain text truncated description.
+ */
+const generateSimpleMetaDescription = (htmlContent, maxLength = 500) => {
+  if (!htmlContent) return '';
+
+  // Use sanitize-html to safely remove all HTML tags
+  // This prevents ReDoS attacks and properly handles malformed HTML
+  const textContent = sanitizeHtml(htmlContent, {
+    allowedTags: [], // Remove all HTML tags
+    allowedAttributes: {},
+    textFilter: function (text) {
+      return text.replace(/\s\s+/g, ' ').trim();
+    },
+  });
+
+  // Truncate and add ellipsis if needed
+  return textContent.length > maxLength
+    ? textContent.substring(0, maxLength - 3) + '...'
+    : textContent;
+};
+
+/**
+ * Validation schema for page input
+ * Pages are similar to posts but do NOT support tags
+ */
+const pageInputSchema = Joi.object({
+  title: Joi.string().max(255).required(),
+  html: Joi.string().required(),
+  custom_excerpt: Joi.string().max(500).optional(),
+  status: Joi.string().valid('draft', 'published', 'scheduled').optional(),
+  published_at: Joi.string().isoDate().optional(),
+  // NO tags field - pages don't support tags
+  feature_image: Joi.string().uri().optional(),
+  feature_image_alt: Joi.string().max(255).optional(),
+  feature_image_caption: Joi.string().max(500).optional(),
+  meta_title: Joi.string().max(70).optional(),
+  meta_description: Joi.string().max(160).optional(),
+});
+
+/**
+ * Service layer function to handle the business logic of creating a page.
+ * Transforms input data, generates metadata defaults.
+ * Note: Pages do NOT support tags (unlike posts).
+ * @param {object} pageInput - Data received from the controller.
+ * @returns {Promise<object>} The created page object from the Ghost API.
+ */
+const createPageService = async (pageInput) => {
+  const logger = createContextLogger('page-service');
+
+  // Validate input to prevent format string vulnerabilities
+  const { error, value: validatedInput } = pageInputSchema.validate(pageInput);
+  if (error) {
+    logger.error('Page input validation failed', {
+      error: error.details[0].message,
+      inputKeys: Object.keys(pageInput),
+    });
+    throw new Error(`Invalid page input: ${error.details[0].message}`);
+  }
+
+  const {
+    title,
+    html,
+    custom_excerpt,
+    status,
+    published_at,
+    // NO tags destructuring - pages don't support tags
+    feature_image,
+    feature_image_alt,
+    feature_image_caption,
+    meta_title,
+    meta_description,
+  } = validatedInput;
+
+  // NO tag resolution section (removed from postService)
+  // Pages do not support tags in Ghost CMS
+
+  // Metadata defaults
+  const finalMetaTitle = meta_title || title;
+  const finalMetaDescription =
+    meta_description || custom_excerpt || generateSimpleMetaDescription(html);
+  const truncatedMetaDescription =
+    finalMetaDescription.length > 500
+      ? finalMetaDescription.substring(0, 497) + '...'
+      : finalMetaDescription;
+
+  // Prepare data for Ghost API
+  const pageDataForApi = {
+    title,
+    html,
+    custom_excerpt,
+    status: status || 'draft',
+    published_at,
+    // NO tags field
+    feature_image,
+    feature_image_alt,
+    feature_image_caption,
+    meta_title: finalMetaTitle,
+    meta_description: truncatedMetaDescription,
+  };
+
+  logger.info('Creating Ghost page', {
+    title: pageDataForApi.title,
+    status: pageDataForApi.status,
+    hasFeatureImage: !!pageDataForApi.feature_image,
+  });
+
+  const newPage = await createGhostPage(pageDataForApi);
+  return newPage;
+};
+
+export { createPageService };


### PR DESCRIPTION
## Summary
- Adds 6 new MCP page tools: `ghost_get_pages`, `ghost_get_page`, `ghost_create_page`, `ghost_update_page`, `ghost_delete_page`, `ghost_search_pages`
- Implements page CRUD functions in ghostServiceImproved.js with full validation, HTML sanitization, and NQL injection prevention
- Creates pageService.js with Joi validation and metadata generation (simplified from postService - no tag support since pages don't use tags)

Fixes #20

## Test plan
- [x] All 733 tests passing
- [x] 90%+ code coverage maintained
- [x] Verified page tools follow same patterns as post tools
- [x] Confirmed pages correctly exclude tag support (Ghost CMS limitation)
- [x] Manual testing with MCP Inspector (optional)