### PR TITLE
fix(mcp): add Zod refinement validation for id or slug parameters

### DIFF
--- a/src/__tests__/mcp_server_improved.test.js
+++ b/src/__tests__/mcp_server_improved.test.js
@@ -394,10 +394,11 @@ describe('mcp_server_improved - ghost_get_post tool', () => {
     expect(tool).toBeDefined();
     expect(tool.description).toContain('post');
     expect(tool.schema).toBeDefined();
-    // Zod schemas store field definitions in schema.shape
-    expect(tool.schema.shape.id).toBeDefined();
-    expect(tool.schema.shape.slug).toBeDefined();
-    expect(tool.schema.shape.include).toBeDefined();
+    // ghost_get_post uses a refined schema, access via _def.schema.shape
+    const shape = tool.schema._def.schema.shape;
+    expect(shape.id).toBeDefined();
+    expect(shape.slug).toBeDefined();
+    expect(shape.include).toBeDefined();
   });
 
   it('should retrieve post by ID', async () => {
@@ -1027,10 +1028,11 @@ describe('ghost_get_tag', () => {
 
   it('should have correct schema with id and slug as optional', () => {
     const tool = mockTools.get('ghost_get_tag');
-    // Zod schemas store field definitions in schema.shape
-    expect(tool.schema.shape.id).toBeDefined();
-    expect(tool.schema.shape.slug).toBeDefined();
-    expect(tool.schema.shape.include).toBeDefined();
+    // ghost_get_tag uses a refined schema, access via _def.schema.shape
+    const shape = tool.schema._def.schema.shape;
+    expect(shape.id).toBeDefined();
+    expect(shape.slug).toBeDefined();
+    expect(shape.include).toBeDefined();
   });
 
   it('should retrieve tag by ID', async () => {
@@ -1089,7 +1091,7 @@ describe('ghost_get_tag', () => {
     const result = await tool.handler({});
 
     expect(result.content[0].type).toBe('text');
-    expect(result.content[0].text).toContain('Either id or slug must be provided');
+    expect(result.content[0].text).toContain('Either id or slug is required');
     expect(result.isError).toBe(true);
   });
 

--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -40,6 +40,13 @@ export class ValidationError extends BaseError {
     this.errors = errors;
   }
 
+  toJSON() {
+    return {
+      ...super.toJSON(),
+      ...(this.errors.length > 0 && { errors: this.errors }),
+    };
+  }
+
   static fromJoi(joiError) {
     const errors = joiError.details.map((detail) => ({
       field: detail.path.join('.'),

--- a/src/mcp_server_improved.js
+++ b/src/mcp_server_improved.js
@@ -82,11 +82,18 @@ const server = new McpServer({
 
 // --- Schema Definitions for Tools ---
 const getTagsSchema = tagQuerySchema.partial();
-const getTagSchema = z.object({
-  id: ghostIdSchema.optional().describe('The ID of the tag to retrieve.'),
-  slug: z.string().optional().describe('The slug of the tag to retrieve.'),
-  include: z.string().optional().describe('Additional resources to include (e.g., "count.posts").'),
-});
+const getTagSchema = z
+  .object({
+    id: ghostIdSchema.optional().describe('The ID of the tag to retrieve.'),
+    slug: z.string().optional().describe('The slug of the tag to retrieve.'),
+    include: z
+      .string()
+      .optional()
+      .describe('Additional resources to include (e.g., "count.posts").'),
+  })
+  .refine((data) => data.id || data.slug, {
+    message: 'Either id or slug is required to retrieve a tag',
+  });
 const updateTagInputSchema = updateTagSchema.extend({ id: ghostIdSchema });
 const deleteTagSchema = z.object({ id: ghostIdSchema });
 
@@ -187,10 +194,6 @@ server.tool(
 
     console.error(`Executing tool: ghost_get_tag`);
     try {
-      if (!id && !slug) {
-        throw new Error('Either id or slug must be provided');
-      }
-
       await loadServices();
 
       // If slug is provided, use the slug/slug-name format
@@ -409,14 +412,18 @@ const getPostsSchema = postQuerySchema.extend({
     .optional()
     .describe('Filter posts by status. Options: published, draft, scheduled, all.'),
 });
-const getPostSchema = z.object({
-  id: ghostIdSchema.optional().describe('The ID of the post to retrieve.'),
-  slug: z.string().optional().describe('The slug of the post to retrieve.'),
-  include: z
-    .string()
-    .optional()
-    .describe('Comma-separated list of relations to include (e.g., "tags,authors").'),
-});
+const getPostSchema = z
+  .object({
+    id: ghostIdSchema.optional().describe('The ID of the post to retrieve.'),
+    slug: z.string().optional().describe('The slug of the post to retrieve.'),
+    include: z
+      .string()
+      .optional()
+      .describe('Comma-separated list of relations to include (e.g., "tags,authors").'),
+  })
+  .refine((data) => data.id || data.slug, {
+    message: 'Either id or slug is required to retrieve a post',
+  });
 const searchPostsSchema = z.object({
   query: z.string().min(1).describe('Search query to find in post titles.'),
   status: z
@@ -534,11 +541,6 @@ server.tool(
 
     console.error(`Executing tool: ghost_get_post`);
     try {
-      // Validate that at least one of id or slug is provided
-      if (!input.id && !input.slug) {
-        throw new Error('Either id or slug is required to retrieve a post');
-      }
-
       await loadServices();
 
       // Build options object


### PR DESCRIPTION
## Summary

- Add `.refine()` validation to `getPostSchema` and `getTagSchema` to enforce that either `id` or `slug` must be provided at schema validation time
- Enhance `ValidationError.toJSON()` to include validation error details in the response
- Remove redundant manual validation checks now that Zod handles this constraint

## Problem

When calling `ghost_get_post` or `ghost_get_tag` without providing `id` or `slug`, the error was thrown at runtime (line 539/197) rather than at schema validation time. This resulted in less informative error messages and inconsistent behavior compared to similar schemas (`getPageSchema`, `getMemberSchema`) that already use `.refine()`.

## Solution

Added Zod `.refine()` validation to both schemas, matching the pattern already used by `getPageSchema` and `getMemberSchema`. Also enhanced `ValidationError.toJSON()` to include the `errors` array so clients can see specific validation failure messages.

## Test plan

- [x] All 1233 tests pass
- [x] Linting passes
- [x] Verified schema shape tests access `_def.schema.shape` for refined schemas
- [x] Verified error message tests expect the new consistent format