### PR TITLE
fix(test): use forks pool to prevent parallel test race conditions

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -5,6 +5,16 @@ export default defineConfig({
     environment: 'node',
     globals: true,
     setupFiles: ['./vitest.setup.js'],
+    // Use forks pool for better module isolation between test files
+    // Each test file runs in its own child process with independent module cache
+    // This prevents race conditions when different test files mock the same module differently
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        // Ensure each test file is fully isolated
+        isolate: true,
+      },
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary

This PR fixes a race condition in Vitest parallel test execution where test files that mock the same module differently can interfere with each other.

**The Problem:**
- `tagRoutes.test.js` mocks `tagController.js` entirely
- `tagController.test.js` imports the **real** `tagController.js` and mocks its dependency
- When running in parallel with the default `threads` pool, module caching can cause one test to get the wrong version of the module

**The Solution:**
Configure Vitest to use `pool: 'forks'` with `isolate: true`, which runs each test file in its own child process with an independent module cache. This provides complete isolation between test files.

## Changes

- Added `pool: 'forks'` configuration to `vitest.config.js`
- Added `poolOptions.forks.isolate: true` for explicit isolation
- Added comments explaining the purpose of the configuration

## Test plan

- [x] All tests pass: `npm test` (35 test files, 1212 tests)
- [x] No flaky failures on consecutive runs: `npm test && npm test && npm test`
- [x] Coverage still works and meets thresholds: `npm run test:coverage`
- [x] Linting passes: `npm run lint`
- [x] Tag routes and controller tests run together without conflict

## Related

- Research: `thoughts/shared/research/2025-12-13-vitest-parallel-race-conditions.md`
- Implementation plan: `thoughts/shared/plans/2025-12-13-vitest-parallel-race-condition-fix.md`
