### PR TITLE
docs: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+title: '[Bug]: '
+labels: ['bug']
+assignees: ''
+---
+
+## Current Behavior / Issue
+
+<!-- Describe what is currently happening that shouldn't be happening -->
+
+## Expected Behavior
+
+<!-- Describe what you expected to happen instead -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Context
+
+<!-- Provide additional context that might be relevant -->
+
+**Environment:**
+- Component (e.g., MCP Server, REST API, Ghost Service):
+- Version:
+- OS:
+- Node version (if applicable):
+
+**Related Issues/PRs:**
+<!-- Link to any related issues or pull requests -->
+
+## Additional Information
+
+<!-- Screenshots, logs, error messages, or anything else that might be helpful -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement
+title: '[Feature]: '
+labels: ['enhancement']
+assignees: ''
+---
+
+## Problem / Use Case
+
+<!-- What problem would this feature solve? What use case does it enable? -->
+
+## Proposed Solution
+
+<!-- Describe how you envision this feature working -->
+
+## Alternative Solutions Considered
+
+<!-- Are there other ways to solve this problem? -->
+
+## Additional Context
+
+<!-- Any other context, mockups, examples, or references that might be helpful -->
+
+**Related Issues/PRs:**
+<!-- Link to any related issues or pull requests -->

--- a/.github/ISSUE_TEMPLATE/feedback.md
+++ b/.github/ISSUE_TEMPLATE/feedback.md
@@ -1,0 +1,28 @@
+---
+name: Feedback
+about: Share feedback, observations, or suggestions
+title: '[Feedback]: '
+labels: ['feedback']
+assignees: ''
+---
+
+## Feedback
+
+<!-- Share your thoughts, observations, or suggestions -->
+
+## Context
+
+<!-- What were you doing when this feedback came to mind? -->
+
+**Component:**
+<!-- Which part of the project does this relate to? -->
+- [ ] MCP Server
+- [ ] REST API
+- [ ] Ghost Service
+- [ ] CLI/Scripts
+- [ ] Documentation
+- [ ] Other
+
+## Additional Notes
+
+<!-- Any other information that might be helpful (optional) -->


### PR DESCRIPTION
## Summary
- Add standardized issue templates for bug reports, feature requests, and general feedback
- Configure template chooser to allow blank issues

## Files Added
- `.github/ISSUE_TEMPLATE/bug_report.md`
- `.github/ISSUE_TEMPLATE/feature_request.md`
- `.github/ISSUE_TEMPLATE/feedback.md`
- `.github/ISSUE_TEMPLATE/config.yml`

## Test plan
- [x] Verify templates appear when creating new issue on GitHub
- [x] Confirm blank issues can still be created