### PR TITLE
Fix/ghost get posts missing parameters

### DIFF
--- a/src/services/ghostServiceImproved.js
+++ b/src/services/ghostServiceImproved.js
@@ -700,13 +700,16 @@ export async function createTag(tagData) {
 }
 
 export async function getTags(options = {}) {
-  const defaultOptions = {
-    limit: options.limit || 15,
-    ...options,
-  };
-
   try {
-    const tags = await handleApiRequest('tags', 'browse', {}, defaultOptions);
+    const tags = await handleApiRequest(
+      'tags',
+      'browse',
+      {},
+      {
+        limit: 15,
+        ...options,
+      }
+    );
     return tags || [];
   } catch (error) {
     console.error('Failed to get tags:', error);


### PR DESCRIPTION
This pull request introduces a comprehensive enhancement to the Ghost CMS tag retrieval functionality, focusing on improved filtering, parameter support, and robust testing. The main changes include a significant refactor of the `ghost_get_tags` tool to support advanced query options, the addition of a utility for safely escaping filter values, and a suite of new tests to ensure correctness and security.

**Enhancements to tag retrieval and filtering:**

* Refactored the `ghost_get_tags` tool in `mcp_server.js` to support advanced options including pagination, sorting, relation inclusion, and filtering by name, slug, visibility, or custom NQL filters. The tool now constructs a filter string from these parameters and passes them to the service layer, enabling much more flexible tag queries. [[1]](diffhunk://#diff-953550ed16a6146542171a5437932efdecabcc9dc6815dca14e65110336416cbL103-R114) [[2]](diffhunk://#diff-953550ed16a6146542171a5437932efdecabcc9dc6815dca14e65110336416cbL115-R149)
* Added the `escapeNqlValue` utility function to safely escape single quotes in NQL filter values, preventing filter injection vulnerabilities when building query strings.
* Updated the `getTags` service function in `ghostServiceImproved.js` to accept an options object, allowing for flexible and extensible tag queries with default and custom parameters.

**Testing improvements:**

* Added an extensive new test suite for the `ghost_get_tags` tool in `mcp_server.test.js`, covering registration, schema validation, parameter passing, filter construction and escaping, error handling, and response formatting. This ensures the new functionality is robust and secure.

**Other API improvements:**

* Extended the `ghost_get_posts` tool to support `fields` and `formats` parameters, improving its flexibility for post queries.