### PR TITLE
Fix test mocks to use GhostAPIError instead of plain Error (JON-40)

### DIFF
--- a/src/services/__tests__/ghostServiceImproved.members.test.js
+++ b/src/services/__tests__/ghostServiceImproved.members.test.js
@@ -31,6 +31,7 @@ import {
   searchMembers,
   api,
 } from '../ghostServiceImproved.js';
+import { GhostAPIError, NotFoundError } from '../../errors/index.js';
 
 describe('ghostServiceImproved - Members', () => {
   beforeEach(() => {
@@ -176,21 +177,20 @@ describe('ghostServiceImproved - Members', () => {
     });
 
     it('should throw validation error for missing member ID', async () => {
-      await expect(updateMember(null, { name: 'Test' })).rejects.toThrow(
-        'Member ID is required for update'
-      );
+      await expect(updateMember(null, { name: 'Test' })).rejects.toThrow('Member ID is required');
     });
 
     // NOTE: Input validation tests (invalid email in update) have been moved to
     // MCP layer tests. The service layer now relies on Zod schema validation.
 
     it('should throw not found error if member does not exist', async () => {
-      api.members.read.mockRejectedValue({
-        response: { status: 404 },
-        message: 'Member not found',
-      });
+      const error404 = new GhostAPIError('members.read', 'Member not found', 404);
+      error404.response = { status: 404 };
+      api.members.read.mockRejectedValue(error404);
 
-      await expect(updateMember('non-existent', { name: 'Test' })).rejects.toThrow();
+      const rejection = updateMember('non-existent', { name: 'Test' });
+      await expect(rejection).rejects.toBeInstanceOf(NotFoundError);
+      await expect(rejection).rejects.toThrow('Member not found');
     });
   });
 
@@ -207,16 +207,17 @@ describe('ghostServiceImproved - Members', () => {
     });
 
     it('should throw validation error for missing member ID', async () => {
-      await expect(deleteMember(null)).rejects.toThrow('Member ID is required for deletion');
+      await expect(deleteMember(null)).rejects.toThrow('Member ID is required');
     });
 
     it('should throw not found error if member does not exist', async () => {
-      api.members.delete.mockRejectedValue({
-        response: { status: 404 },
-        message: 'Member not found',
-      });
+      const error404 = new GhostAPIError('members.delete', 'Member not found', 404);
+      error404.response = { status: 404 };
+      api.members.delete.mockRejectedValue(error404);
 
-      await expect(deleteMember('non-existent')).rejects.toThrow();
+      const rejection = deleteMember('non-existent');
+      await expect(rejection).rejects.toBeInstanceOf(NotFoundError);
+      await expect(rejection).rejects.toThrow('Member not found');
     });
   });
 
@@ -358,12 +359,13 @@ describe('ghostServiceImproved - Members', () => {
     // moved to MCP layer tests. The service layer now relies on Zod schema validation.
 
     it('should throw not found error when member not found by ID', async () => {
-      api.members.read.mockRejectedValue({
-        response: { status: 404 },
-        message: 'Member not found',
-      });
+      const error404 = new GhostAPIError('members.read', 'Member not found', 404);
+      error404.response = { status: 404 };
+      api.members.read.mockRejectedValue(error404);
 
-      await expect(getMember({ id: 'non-existent' })).rejects.toThrow();
+      const rejection = getMember({ id: 'non-existent' });
+      await expect(rejection).rejects.toBeInstanceOf(NotFoundError);
+      await expect(rejection).rejects.toThrow('Member not found');
     });
 
     it('should throw not found error when member not found by email', async () => {

--- a/src/services/__tests__/ghostServiceImproved.pages.test.js
+++ b/src/services/__tests__/ghostServiceImproved.pages.test.js
@@ -33,6 +33,7 @@ import {
   validators,
 } from '../ghostServiceImproved.js';
 import { createPageSchema, updatePageSchema } from '../../schemas/pageSchemas.js';
+import { GhostAPIError, NotFoundError, ValidationError } from '../../errors/index.js';
 
 describe('ghostServiceImproved - Pages', () => {
   beforeEach(() => {
@@ -205,13 +206,13 @@ describe('ghostServiceImproved - Pages', () => {
     });
 
     it('should handle Ghost API validation errors (422)', async () => {
-      const error422 = new Error('Validation failed');
+      const error422 = new GhostAPIError('pages.add', 'Validation failed', 422);
       error422.response = { status: 422 };
       api.pages.add.mockRejectedValue(error422);
 
-      await expect(createPage({ title: 'Test', html: '<p>Content</p>' })).rejects.toThrow(
-        'Page creation failed due to validation errors'
-      );
+      const rejection = createPage({ title: 'Test', html: '<p>Content</p>' });
+      await expect(rejection).rejects.toBeInstanceOf(ValidationError);
+      await expect(rejection).rejects.toThrow('Page creation failed due to validation errors');
     });
 
     it('should NOT include tags in page creation (pages do not support tags)', async () => {
@@ -272,13 +273,13 @@ describe('ghostServiceImproved - Pages', () => {
     });
 
     it('should handle page not found (404)', async () => {
-      const error404 = new Error('Page not found');
+      const error404 = new GhostAPIError('pages.read', 'Page not found', 404);
       error404.response = { status: 404 };
       api.pages.read.mockRejectedValue(error404);
 
-      await expect(updatePage('nonexistent-id', { title: 'Updated' })).rejects.toThrow(
-        'Page not found'
-      );
+      const rejection = updatePage('nonexistent-id', { title: 'Updated' });
+      await expect(rejection).rejects.toBeInstanceOf(NotFoundError);
+      await expect(rejection).rejects.toThrow('Page not found');
     });
 
     it('should preserve updated_at timestamp for conflict resolution', async () => {
@@ -369,8 +370,8 @@ describe('ghostServiceImproved - Pages', () => {
 
   describe('deletePage', () => {
     it('should throw error when page ID is missing', async () => {
-      await expect(deletePage(null)).rejects.toThrow('Page ID is required for deletion');
-      await expect(deletePage('')).rejects.toThrow('Page ID is required for deletion');
+      await expect(deletePage(null)).rejects.toThrow('Page ID is required');
+      await expect(deletePage('')).rejects.toThrow('Page ID is required');
     });
 
     it('should delete page successfully', async () => {
@@ -385,11 +386,13 @@ describe('ghostServiceImproved - Pages', () => {
     });
 
     it('should handle page not found (404)', async () => {
-      const error404 = new Error('Page not found');
+      const error404 = new GhostAPIError('pages.delete', 'Page not found', 404);
       error404.response = { status: 404 };
       api.pages.delete.mockRejectedValue(error404);
 
-      await expect(deletePage('nonexistent-id')).rejects.toThrow('Page not found');
+      const rejection = deletePage('nonexistent-id');
+      await expect(rejection).rejects.toBeInstanceOf(NotFoundError);
+      await expect(rejection).rejects.toThrow('Page not found');
     });
   });
 
@@ -433,11 +436,13 @@ describe('ghostServiceImproved - Pages', () => {
     });
 
     it('should handle page not found (404)', async () => {
-      const error404 = new Error('Page not found');
+      const error404 = new GhostAPIError('pages.read', 'Page not found', 404);
       error404.response = { status: 404 };
       api.pages.read.mockRejectedValue(error404);
 
-      await expect(getPage('nonexistent-id')).rejects.toThrow('Page not found');
+      const rejection = getPage('nonexistent-id');
+      await expect(rejection).rejects.toBeInstanceOf(NotFoundError);
+      await expect(rejection).rejects.toThrow('Page not found');
     });
   });
 

--- a/src/services/__tests__/ghostServiceImproved.posts.test.js
+++ b/src/services/__tests__/ghostServiceImproved.posts.test.js
@@ -24,6 +24,7 @@ vi.mock('fs/promises', () => ({
 // Import after setting up mocks
 import { updatePost, api, validators } from '../ghostServiceImproved.js';
 import { updatePostSchema } from '../../schemas/postSchemas.js';
+import { GhostAPIError, NotFoundError } from '../../errors/index.js';
 
 describe('ghostServiceImproved - Posts (updatePost)', () => {
   beforeEach(() => {
@@ -86,22 +87,18 @@ describe('ghostServiceImproved - Posts (updatePost)', () => {
     });
 
     it('should throw error when post ID is missing', async () => {
-      await expect(updatePost(null, { title: 'Updated' })).rejects.toThrow(
-        'Post ID is required for update'
-      );
-      await expect(updatePost('', { title: 'Updated' })).rejects.toThrow(
-        'Post ID is required for update'
-      );
+      await expect(updatePost(null, { title: 'Updated' })).rejects.toThrow('Post ID is required');
+      await expect(updatePost('', { title: 'Updated' })).rejects.toThrow('Post ID is required');
     });
 
     it('should handle post not found (404)', async () => {
-      const error404 = new Error('Post not found');
+      const error404 = new GhostAPIError('posts.read', 'Post not found', 404);
       error404.response = { status: 404 };
       api.posts.read.mockRejectedValue(error404);
 
-      await expect(updatePost('nonexistent-id', { title: 'Updated' })).rejects.toThrow(
-        'Post not found'
-      );
+      const rejection = updatePost('nonexistent-id', { title: 'Updated' });
+      await expect(rejection).rejects.toBeInstanceOf(NotFoundError);
+      await expect(rejection).rejects.toThrow('Post not found');
     });
 
     it('should throw ValidationError when updating to scheduled without published_at', async () => {

--- a/src/services/__tests__/ghostServiceImproved.tags.test.js
+++ b/src/services/__tests__/ghostServiceImproved.tags.test.js
@@ -31,6 +31,7 @@ import {
   api,
   ghostCircuitBreaker,
 } from '../ghostServiceImproved.js';
+import { GhostAPIError, NotFoundError } from '../../errors/index.js';
 
 describe('ghostServiceImproved - Tags', () => {
   beforeEach(() => {
@@ -250,12 +251,13 @@ describe('ghostServiceImproved - Tags', () => {
     });
 
     it('should throw not found error when tag does not exist', async () => {
-      api.tags.read.mockRejectedValue({
-        response: { status: 404 },
-        message: 'Tag not found',
-      });
+      const error404 = new GhostAPIError('tags.read', 'Tag not found', 404);
+      error404.response = { status: 404 };
+      api.tags.read.mockRejectedValue(error404);
 
-      await expect(getTag('non-existent')).rejects.toThrow();
+      const rejection = getTag('non-existent');
+      await expect(rejection).rejects.toBeInstanceOf(NotFoundError);
+      await expect(rejection).rejects.toThrow('Tag not found');
     });
   });
 
@@ -343,10 +345,9 @@ describe('ghostServiceImproved - Tags', () => {
       };
 
       // First call fails with duplicate error
-      api.tags.add.mockRejectedValue({
-        response: { status: 422 },
-        message: 'Tag already exists',
-      });
+      const error422 = new GhostAPIError('tags.add', 'Tag already exists', 422);
+      error422.response = { status: 422, data: { errors: [{ message: 'Tag already exists' }] } };
+      api.tags.add.mockRejectedValue(error422);
 
       // getTags returns existing tag when called with name filter
       api.tags.browse.mockResolvedValue([{ id: 'tag-1', name: 'JavaScript', slug: 'javascript' }]);
@@ -405,18 +406,17 @@ describe('ghostServiceImproved - Tags', () => {
     });
 
     it('should throw validation error for missing tag ID', async () => {
-      await expect(updateTag(null, { name: 'Test' })).rejects.toThrow(
-        'Tag ID is required for update'
-      );
+      await expect(updateTag(null, { name: 'Test' })).rejects.toThrow('Tag ID is required');
     });
 
     it('should throw not found error if tag does not exist', async () => {
-      api.tags.read.mockRejectedValue({
-        response: { status: 404 },
-        message: 'Tag not found',
-      });
+      const error404 = new GhostAPIError('tags.read', 'Tag not found', 404);
+      error404.response = { status: 404 };
+      api.tags.read.mockRejectedValue(error404);
 
-      await expect(updateTag('non-existent', { name: 'Test' })).rejects.toThrow();
+      const rejection = updateTag('non-existent', { name: 'Test' });
+      await expect(rejection).rejects.toBeInstanceOf(NotFoundError);
+      await expect(rejection).rejects.toThrow('Tag not found');
     });
   });
 
@@ -433,16 +433,17 @@ describe('ghostServiceImproved - Tags', () => {
     });
 
     it('should throw validation error for missing tag ID', async () => {
-      await expect(deleteTag(null)).rejects.toThrow('Tag ID is required for deletion');
+      await expect(deleteTag(null)).rejects.toThrow('Tag ID is required');
     });
 
     it('should throw not found error if tag does not exist', async () => {
-      api.tags.delete.mockRejectedValue({
-        response: { status: 404 },
-        message: 'Tag not found',
-      });
+      const error404 = new GhostAPIError('tags.delete', 'Tag not found', 404);
+      error404.response = { status: 404 };
+      api.tags.delete.mockRejectedValue(error404);
 
-      await expect(deleteTag('non-existent')).rejects.toThrow();
+      const rejection = deleteTag('non-existent');
+      await expect(rejection).rejects.toBeInstanceOf(NotFoundError);
+      await expect(rejection).rejects.toThrow('Tag not found');
     });
   });
 });


### PR DESCRIPTION
Assignee: @jgardner04

## Summary

- Replace plain `Error` objects with `GhostAPIError` instances in 404/422 error mocks across 4 service test files
- Add `.response` property to mock errors so they survive re-wrapping through `ErrorHandler.fromGhostError()`
- Assert specific error types (`NotFoundError`, `ValidationError`) instead of generic error checks

## Implementation Approach

The test mocks previously used plain `Error` objects or plain objects with `response` properties to simulate Ghost API errors. This didn't match production behavior where `handleApiRequest` wraps all errors through `ErrorHandler.fromGhostError()`, which creates `GhostAPIError` instances.

**Key changes per file:**
- **posts.test.js**: Updated 404 mock to use `GhostAPIError`, assert `NotFoundError`
- **pages.test.js**: Updated 422 mock to use `GhostAPIError` with `ValidationError` assertion, plus 3x 404 mocks with `NotFoundError` assertions
- **tags.test.js**: Updated 404 mocks and duplicate tag (422) mock with proper `.response.data.errors` for the "already exists" check
- **members.test.js**: Updated 3x 404 mocks to use `GhostAPIError`, assert `NotFoundError`

## Testing

- All 121 tests pass across the 4 modified test files
- Full test suite (1311 tests) passes via pre-push hook
- ESLint/Prettier clean

## Breaking Changes

None. Test-only changes.

## Linear Issue

[JON-40](https://linear.app/cyrus-dev/issue/JON-40)

<!-- generated-by-cyrus -->