### PR TITLE
docs: add changelog entry for shared Ghost API test mock factory (JON-38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Shared test mock factory for Ghost Admin API** - Extracted duplicated `vi.mock('@tryghost/admin-api')` blocks from 6 test files into a single `mockGhostApi.js` helper with `createMockGhostApi()`, `createMockGhostApiConstructor()`, and `mockGhostApiModule()` exports. Fixes silent inconsistency where the pages test was missing the `members` resource. ([JON-38](https://linear.app/jonathangardner/issue/JON-38/extract-shared-test-mock-factory-for-ghost-admin-api), [#127](https://github.com/jgardner04/Ghost-MCP-Server/pull/127))
+
 ### Fixed
 
 - **Scheduled status validation on published_at-only updates** - `updatePost` and `updatePage` now validate scheduled-date constraints when only `published_at` changes (without `status` in the update payload). Previously, a scheduled post/page could have its publish date set to the past without triggering validation. ([JON-19](https://linear.app/jonathangardner/issue/JON-19/edge-case-validatescheduledstatus-skipped-when-only-published-at), [#136](https://github.com/jgardner04/Ghost-MCP-Server/pull/136))


### PR DESCRIPTION
Assignee: @jgardner04 ([jonathan](https://linear.app/jonathangardner/profiles/jonathan))

## Summary

- Adds a changelog entry under `## [Unreleased] > ### Changed` for the shared Ghost Admin API test mock factory extraction completed in PR #127

## Context

The implementation work for JON-38 was completed and merged in [#127](https://github.com/jgardner04/Ghost-MCP-Server/pull/127). This PR adds the missing changelog entry documenting that change.

## Changes

- **CHANGELOG.md**: Added entry describing the extraction of duplicated `vi.mock('@tryghost/admin-api')` blocks from 6 test files into `src/__tests__/helpers/mockGhostApi.js`, including the fix for the silent inconsistency where the pages test was missing the `members` resource.

## Test plan

- [x] No code changes — changelog-only update
- [x] All 192 Ghost service tests passing (verified before committing)

## Linear issue

[JON-38: Extract shared test mock factory for Ghost Admin API](https://linear.app/jonathangardner/issue/JON-38/extract-shared-test-mock-factory-for-ghost-admin-api)

<!-- generated-by-cyrus -->