### PR TITLE
Add comment explaining why schema is passed twice in registerTool calls (JON-83)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Dual schema passing comment** - Added explanatory comment to `withErrorHandling` JSDoc clarifying why each `registerTool` call passes the schema twice (MCP protocol metadata vs. runtime validation). ([JON-83](https://linear.app/jonathangardner/issue/JON-83/add-comment-explaining-why-schema-is-passed-twice-in-registertool), [#142](https://github.com/jgardner04/Ghost-MCP-Server/pull/142))
 - **Standardized tool error handling** - Extracted `withErrorHandling` higher-order function to eliminate ~735 lines of duplicated try/catch blocks across 33 tool handlers. Error messages now use a consistent `Error in <tool_name>: <message>` format. ([JON-17](https://linear.app/jonathangardner/issue/JON-17/extract-error-handler-hof-in-mcp-serverjs-to-reduce-duplication), [#138](https://github.com/jgardner04/Ghost-MCP-Server/pull/138))
 - **JSDoc documentation, validation helper extraction, and export cleanup** - Added `@param`/`@returns`/`@throws` JSDoc to ~32 functions, extracted `validators.requireId()` shared helper replacing 10+ inline ID checks, and removed unused `handleApiRequest` backward-compat export. ([JON-18](https://linear.app/jonathangardner/issue/JON-18/jsdoc-gaps-unused-export-cleanup-and-validation-helper-extraction), [#141](https://github.com/jgardner04/Ghost-MCP-Server/pull/141))
 

--- a/src/mcp_server.js
+++ b/src/mcp_server.js
@@ -87,6 +87,11 @@ const escapeNqlValue = (value) => {
  * Higher-order function that wraps a tool handler with standardized
  * input validation, service loading, and error handling.
  *
+ * Note: Each registerTool call passes the schema twice — once as `inputSchema`
+ * (MCP protocol metadata exposed to clients) and once here for runtime input
+ * validation via validateToolInput. These serve different purposes and both
+ * are required.
+ *
  * @param {string} toolName - The tool identifier (e.g., 'ghost_get_tags')
  * @param {object} schema - Zod schema for input validation
  * @param {Function} handler - Async function receiving validated input, returns MCP response


### PR DESCRIPTION
Assignee: @jgardner04 ([jonathan](https://linear.app/jonathangardner/profiles/jonathan))

## Summary

- Added an explanatory comment to the `withErrorHandling` JSDoc clarifying why each `registerTool` call passes the schema twice: once as `inputSchema` (MCP protocol metadata exposed to clients) and once to `withErrorHandling` for runtime input validation via `validateToolInput`

## Implementation

Comment added to the HOF definition rather than repeated on every call site, per the issue's acceptance criteria. No functional changes.

## Testing

- All 1312 tests pass across 38 test files
- ESLint clean
- Comment-only change with no runtime impact

## Linear Issue

[JON-83: Add comment explaining why schema is passed twice in registerTool calls](https://linear.app/jonathangardner/issue/JON-83/add-comment-explaining-why-schema-is-passed-twice-in-registertool)

<!-- generated-by-cyrus -->