### PR TITLE
test: add JSON Schema regression tests for MCP tool schemas (JON-103)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ tasks/
 thoughts/
 
 # Test coverage
-coverage/ .serena/
+coverage/
+.serena/

--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ tasks/
 thoughts/
 
 # Test coverage
-coverage/ 
+coverage/ .serena/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **JSON Schema regression tests for MCP tool schemas** - Added tests verifying every registered tool produces non-empty JSON Schema `properties` via the same `zod/v4-mini` conversion path the MCP SDK uses. Includes targeted assertions that `ghost_create_post` and `ghost_create_page` declare `title` and `html` as required. Prevents a regression where empty schemas caused MCP clients to strip arguments. ([JON-103](https://linear.app/jonathangardner/issue/JON-103/declare-input-schema-for-ghost-create-post-tool))
+
 ### Changed
 
 - **Dual schema passing comment** - Added explanatory comment to `withErrorHandling` JSDoc clarifying why each `registerTool` call passes the schema twice (MCP protocol metadata vs. runtime validation). ([JON-83](https://linear.app/jonathangardner/issue/JON-83/add-comment-explaining-why-schema-is-passed-twice-in-registertool), [#142](https://github.com/jgardner04/Ghost-MCP-Server/pull/142))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ All code written for this project MUST follow OWASP security best practices to p
 - `express-rate-limit` - Rate limiting
 - `crypto` - Secure random generation and comparisons
 - `helmet` - HTTP security headers
-- `joi` - Legacy validation (used in some REST endpoints)
+- `joi` - Legacy validation (used in some REST endpoints; do not use for new code — prefer Zod schemas)
 
 ## Git Workflow (Required)
 
@@ -219,6 +219,7 @@ Follow these principles when writing code:
    - `tempFileManager.js`: Temp file tracking and cleanup with process exit handlers
    - `urlValidator.js`: SSRF-safe URL validation for image downloads
    - `logger.js`: Context-aware logging with request correlation
+   - `nqlSanitizer.js`: NQL query sanitization (consolidated from memberService and tierService)
 
 ### Environment Configuration
 

--- a/src/__tests__/mcp_server.test.js
+++ b/src/__tests__/mcp_server.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as z4mini from 'zod/v4-mini';
 
 // Mock the McpServer to capture tool registrations
 const mockTools = new Map();
@@ -1642,5 +1643,57 @@ describe('ghost_delete_tag', () => {
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('Failed to delete tag');
+  });
+});
+
+// --- JSON Schema regression tests (JON-103) ---
+// Verifies that every registered MCP tool exposes a non-empty JSON Schema
+// to clients. Uses zod/v4-mini's toJSONSchema — the same converter the
+// MCP SDK calls internally (see zod-json-schema-compat.js).
+describe('tool schema JSON Schema output', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    if (mockTools.size === 0) {
+      await import('../mcp_server.js');
+    }
+  });
+
+  it('should produce non-empty properties for every registered tool', () => {
+    expect(mockTools.size).toBeGreaterThan(0);
+
+    for (const [name, tool] of mockTools) {
+      const schema = tool.schema;
+
+      // Schema must be a Zod object with a shape
+      expect(schema.shape, `${name}: missing Zod shape`).toBeDefined();
+      expect(Object.keys(schema.shape).length, `${name}: shape has no keys`).toBeGreaterThan(0);
+
+      // Convert via the same path the MCP SDK uses
+      const jsonSchema = z4mini.toJSONSchema(schema, {
+        target: 'draft-7',
+        io: 'input',
+      });
+
+      expect(jsonSchema.type, `${name}: type should be 'object'`).toBe('object');
+      expect(
+        Object.keys(jsonSchema.properties || {}).length,
+        `${name}: JSON Schema properties is empty`
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it('should declare title and html as required for ghost_create_post and ghost_create_page', () => {
+    for (const toolName of ['ghost_create_post', 'ghost_create_page']) {
+      const tool = mockTools.get(toolName);
+      const jsonSchema = z4mini.toJSONSchema(tool.schema, {
+        target: 'draft-7',
+        io: 'input',
+      });
+
+      expect(jsonSchema.required, `${toolName}: title not required`).toContain('title');
+      expect(jsonSchema.required, `${toolName}: html not required`).toContain('html');
+      expect(jsonSchema.properties.title.type, `${toolName}: title type`).toBe('string');
+      expect(jsonSchema.properties.html.type, `${toolName}: html type`).toBe('string');
+    }
   });
 });

--- a/src/__tests__/mcp_server.test.js
+++ b/src/__tests__/mcp_server.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import * as z4mini from 'zod/v4-mini';
 
 // Mock the McpServer to capture tool registrations
@@ -1651,8 +1651,7 @@ describe('ghost_delete_tag', () => {
 // to clients. Uses zod/v4-mini's toJSONSchema — the same converter the
 // MCP SDK calls internally (see zod-json-schema-compat.js).
 describe('tool schema JSON Schema output', () => {
-  beforeEach(async () => {
-    vi.clearAllMocks();
+  beforeAll(async () => {
     if (mockTools.size === 0) {
       await import('../mcp_server.js');
     }
@@ -1685,6 +1684,7 @@ describe('tool schema JSON Schema output', () => {
   it('should declare title and html as required for ghost_create_post and ghost_create_page', () => {
     for (const toolName of ['ghost_create_post', 'ghost_create_page']) {
       const tool = mockTools.get(toolName);
+      expect(tool, `${toolName}: tool not found in registry`).toBeDefined();
       const jsonSchema = z4mini.toJSONSchema(tool.schema, {
         target: 'draft-7',
         io: 'input',

--- a/src/__tests__/mcp_server.test.js
+++ b/src/__tests__/mcp_server.test.js
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+// zod/v4-mini is a subpath export of zod@^4 — used here because the MCP SDK's
+// internal JSON Schema converter (zod-json-schema-compat.js) uses this same module.
 import * as z4mini from 'zod/v4-mini';
 
 // Mock the McpServer to capture tool registrations
@@ -1687,6 +1689,7 @@ describe('tool schema JSON Schema output', () => {
       expect(tool, `${toolName}: tool not found in registry`).toBeDefined();
       const jsonSchema = z4mini.toJSONSchema(tool.schema, JSON_SCHEMA_OPTS);
 
+      expect(jsonSchema.properties, `${toolName}: properties missing`).toBeDefined();
       expect(jsonSchema.required, `${toolName}: title not required`).toContain('title');
       expect(jsonSchema.required, `${toolName}: html not required`).toContain('html');
       expect(jsonSchema.properties.title.type, `${toolName}: title type`).toBe('string');

--- a/src/__tests__/mcp_server.test.js
+++ b/src/__tests__/mcp_server.test.js
@@ -1651,6 +1651,9 @@ describe('ghost_delete_tag', () => {
 // to clients. Uses zod/v4-mini's toJSONSchema — the same converter the
 // MCP SDK calls internally (see zod-json-schema-compat.js).
 describe('tool schema JSON Schema output', () => {
+  // Matches the MCP SDK's internal conversion options (see zod-json-schema-compat.js)
+  const JSON_SCHEMA_OPTS = { target: 'draft-7', io: 'input' };
+
   beforeAll(async () => {
     if (mockTools.size === 0) {
       await import('../mcp_server.js');
@@ -1668,10 +1671,7 @@ describe('tool schema JSON Schema output', () => {
       expect(Object.keys(schema.shape).length, `${name}: shape has no keys`).toBeGreaterThan(0);
 
       // Convert via the same path the MCP SDK uses
-      const jsonSchema = z4mini.toJSONSchema(schema, {
-        target: 'draft-7',
-        io: 'input',
-      });
+      const jsonSchema = z4mini.toJSONSchema(schema, JSON_SCHEMA_OPTS);
 
       expect(jsonSchema.type, `${name}: type should be 'object'`).toBe('object');
       expect(
@@ -1685,10 +1685,7 @@ describe('tool schema JSON Schema output', () => {
     for (const toolName of ['ghost_create_post', 'ghost_create_page']) {
       const tool = mockTools.get(toolName);
       expect(tool, `${toolName}: tool not found in registry`).toBeDefined();
-      const jsonSchema = z4mini.toJSONSchema(tool.schema, {
-        target: 'draft-7',
-        io: 'input',
-      });
+      const jsonSchema = z4mini.toJSONSchema(tool.schema, JSON_SCHEMA_OPTS);
 
       expect(jsonSchema.required, `${toolName}: title not required`).toContain('title');
       expect(jsonSchema.required, `${toolName}: html not required`).toContain('html');


### PR DESCRIPTION
## Summary

- Adds regression tests verifying every registered MCP tool produces non-empty JSON Schema `properties` via the same `zod/v4-mini` conversion path the MCP SDK uses internally
- Includes targeted assertions that `ghost_create_post` and `ghost_create_page` declare `title` and `html` as `required` with `type: "string"`
- Updates CLAUDE.md: adds missing `nqlSanitizer.js` to Utilities listing, adds deprecation note on `joi`
- Adds `.serena/` to `.gitignore`

Resolves [JON-103](https://linear.app/jonathangardner/issue/JON-103/declare-input-schema-for-ghost-create-post-tool)

## Test plan

- [ ] `npm test` passes (100 tests in mcp_server.test.js, 1315 total)
- [ ] `npm run lint` passes with no errors
- [ ] Verify new `describe('tool schema JSON Schema output')` block runs 2 test cases
- [ ] Confirm no changes to production code — test-only + docs