### PR TITLE
Fix test and documentation gaps in createResourceService factory (JON-105)

### DIFF
--- a/src/services/__tests__/createResourceService.test.js
+++ b/src/services/__tests__/createResourceService.test.js
@@ -135,6 +135,23 @@ describe('createResourceService', () => {
       expect(validateCreate).toHaveBeenCalledBefore(api.posts.add);
     });
 
+    it('should support async validateCreate', async () => {
+      const validateCreate = vi.fn().mockResolvedValue(undefined);
+      const service = createResourceService({
+        resource: 'posts',
+        label: 'Post',
+        validateCreate,
+      });
+
+      const data = { title: 'Test' };
+      api.posts.add.mockResolvedValue({ id: '1', ...data });
+
+      await service.create(data);
+
+      expect(validateCreate).toHaveBeenCalledWith(data);
+      expect(api.posts.add).toHaveBeenCalled();
+    });
+
     it('should not call API if validateCreate throws', async () => {
       const validateCreate = vi.fn(() => {
         throw new ValidationError('Invalid data');
@@ -159,7 +176,7 @@ describe('createResourceService', () => {
       ghostError.response = { status: 422 };
       api.posts.add.mockRejectedValue(ghostError);
 
-      await expect(service.create({ title: 'Test' })).rejects.toThrow();
+      await expect(service.create({ title: 'Test' })).rejects.toThrow(ValidationError);
     });
 
     it('should re-throw non-422 errors', async () => {

--- a/src/services/createResourceService.js
+++ b/src/services/createResourceService.js
@@ -24,6 +24,9 @@ import { validators } from './validators.js';
  * @param {Function} [config.validateUpdate] - Validation function called before update: (id, data) => void | Promise<void>
  * @param {boolean} [config.catch422OnUpdate=false] - Whether to catch 422 errors on update and wrap as ValidationError
  * @returns {Object} Object with { create, update, remove, getOne, getList } methods
+ *
+ * SECURITY: HTML content must be sanitized before reaching this function.
+ * See htmlContentSchema in schemas/common.js for the validation gate.
  */
 export function createResourceService(config) {
   const {


### PR DESCRIPTION
## Summary

Follow-up to PR #144 (JON-36) addressing three minor gaps identified during code review:

- **Strengthened 422 create test assertion**: Changed `.rejects.toThrow()` to `.rejects.toThrow(ValidationError)` to match the specificity of other error type assertions in the test suite
- **Added missing async validateCreate test**: The factory's key fix was `await`ing `validateCreate`, but only async `validateUpdate` had a test. Added a parallel test using `vi.fn().mockResolvedValue(undefined)`
- **Restored HTML sanitization security comment**: The `createPost`/`createPage` security invariant comment about HTML sanitization was lost during factory extraction. Added equivalent note to `createResourceService` JSDoc

## Test plan

- [x] All 28 createResourceService tests pass (including the new async validateCreate test)
- [x] Lint-staged (ESLint + Prettier) passes