### PR TITLE
Remove redundant .response assignment on 404 GhostAPIError mocks (JON-80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **JSON Schema regression tests for MCP tool schemas** - Added tests verifying every registered tool produces non-empty JSON Schema `properties` via the same `zod/v4-mini` conversion path the MCP SDK uses. Includes targeted assertions that `ghost_create_post` and `ghost_create_page` declare `title` and `html` as required. Prevents a regression where empty schemas caused MCP clients to strip arguments. ([JON-103](https://linear.app/jonathangardner/issue/JON-103/declare-input-schema-for-ghost-create-post-tool))
 
+### Removed
+
+- **Redundant `.response` assignment on 404 GhostAPIError mocks** - Removed manual `error404.response = { status: 404 }` assignments from 4 test files (posts, pages, tags, members). `GhostAPIError` already sets `this.statusCode = 404`, and `fromGhostError` falls back to `error.statusCode` when `error.response?.status` is absent. ([JON-80](https://linear.app/jonathangardner/issue/JON-80/remove-redundant-response-assignment-on-404-ghostapierror-mocks))
+
 ### Changed
 
 - **Extract shared CRUD resource factory** - Introduced `createResourceService()` factory to eliminate duplicated CRUD patterns (create/update/delete/getOne/getList) across 6 domain service modules. Posts, Pages, Members, Newsletters, and Tiers now delegate common operations to the factory while preserving domain-specific logic as config hooks. ([JON-36](https://linear.app/jonathangardner/issue/JON-36/extract-shared-crud-resource-factory-to-eliminate-postpage-duplication), [#144](https://github.com/jgardner04/Ghost-MCP-Server/pull/144))

--- a/src/services/__tests__/ghostServiceImproved.members.test.js
+++ b/src/services/__tests__/ghostServiceImproved.members.test.js
@@ -185,7 +185,6 @@ describe('ghostServiceImproved - Members', () => {
 
     it('should throw not found error if member does not exist', async () => {
       const error404 = new GhostAPIError('members.read', 'Member not found', 404);
-      error404.response = { status: 404 };
       api.members.read.mockRejectedValue(error404);
 
       const rejection = updateMember('non-existent', { name: 'Test' });
@@ -212,7 +211,6 @@ describe('ghostServiceImproved - Members', () => {
 
     it('should throw not found error if member does not exist', async () => {
       const error404 = new GhostAPIError('members.delete', 'Member not found', 404);
-      error404.response = { status: 404 };
       api.members.delete.mockRejectedValue(error404);
 
       const rejection = deleteMember('non-existent');
@@ -360,7 +358,6 @@ describe('ghostServiceImproved - Members', () => {
 
     it('should throw not found error when member not found by ID', async () => {
       const error404 = new GhostAPIError('members.read', 'Member not found', 404);
-      error404.response = { status: 404 };
       api.members.read.mockRejectedValue(error404);
 
       const rejection = getMember({ id: 'non-existent' });

--- a/src/services/__tests__/ghostServiceImproved.pages.test.js
+++ b/src/services/__tests__/ghostServiceImproved.pages.test.js
@@ -274,7 +274,6 @@ describe('ghostServiceImproved - Pages', () => {
 
     it('should handle page not found (404)', async () => {
       const error404 = new GhostAPIError('pages.read', 'Page not found', 404);
-      error404.response = { status: 404 };
       api.pages.read.mockRejectedValue(error404);
 
       const rejection = updatePage('nonexistent-id', { title: 'Updated' });
@@ -387,7 +386,6 @@ describe('ghostServiceImproved - Pages', () => {
 
     it('should handle page not found (404)', async () => {
       const error404 = new GhostAPIError('pages.delete', 'Page not found', 404);
-      error404.response = { status: 404 };
       api.pages.delete.mockRejectedValue(error404);
 
       const rejection = deletePage('nonexistent-id');
@@ -437,7 +435,6 @@ describe('ghostServiceImproved - Pages', () => {
 
     it('should handle page not found (404)', async () => {
       const error404 = new GhostAPIError('pages.read', 'Page not found', 404);
-      error404.response = { status: 404 };
       api.pages.read.mockRejectedValue(error404);
 
       const rejection = getPage('nonexistent-id');

--- a/src/services/__tests__/ghostServiceImproved.posts.test.js
+++ b/src/services/__tests__/ghostServiceImproved.posts.test.js
@@ -93,7 +93,6 @@ describe('ghostServiceImproved - Posts (updatePost)', () => {
 
     it('should handle post not found (404)', async () => {
       const error404 = new GhostAPIError('posts.read', 'Post not found', 404);
-      error404.response = { status: 404 };
       api.posts.read.mockRejectedValue(error404);
 
       const rejection = updatePost('nonexistent-id', { title: 'Updated' });

--- a/src/services/__tests__/ghostServiceImproved.tags.test.js
+++ b/src/services/__tests__/ghostServiceImproved.tags.test.js
@@ -252,7 +252,6 @@ describe('ghostServiceImproved - Tags', () => {
 
     it('should throw not found error when tag does not exist', async () => {
       const error404 = new GhostAPIError('tags.read', 'Tag not found', 404);
-      error404.response = { status: 404 };
       api.tags.read.mockRejectedValue(error404);
 
       const rejection = getTag('non-existent');
@@ -411,7 +410,6 @@ describe('ghostServiceImproved - Tags', () => {
 
     it('should throw not found error if tag does not exist', async () => {
       const error404 = new GhostAPIError('tags.read', 'Tag not found', 404);
-      error404.response = { status: 404 };
       api.tags.read.mockRejectedValue(error404);
 
       const rejection = updateTag('non-existent', { name: 'Test' });
@@ -438,7 +436,6 @@ describe('ghostServiceImproved - Tags', () => {
 
     it('should throw not found error if tag does not exist', async () => {
       const error404 = new GhostAPIError('tags.delete', 'Tag not found', 404);
-      error404.response = { status: 404 };
       api.tags.delete.mockRejectedValue(error404);
 
       const rejection = deleteTag('non-existent');


### PR DESCRIPTION
Assignee: @jgardner04 ([jonathan](https://linear.app/jonathangardner/profiles/jonathan))

## Summary

- Removed 10 redundant `error404.response = { status: 404 }` assignments across 4 test files (`ghostServiceImproved.posts.test.js`, `.pages.test.js`, `.tags.test.js`, `.members.test.js`)
- `GhostAPIError` already sets `this.statusCode = 404` when constructed with a 404 status code, and `ErrorHandler.fromGhostError()` falls back to `error.statusCode` when `error.response?.status` is absent
- Updated CHANGELOG with a "Removed" entry under `[Unreleased]`

## Test plan

- [x] All 121 tests in the 4 affected test files pass
- [x] Full test suite (1342 tests) passes
- [x] ESLint and Prettier pass (via pre-commit hooks)
- [x] Verified zero remaining `error404.response =` occurrences in the scoped files

Closes [JON-80](https://linear.app/jonathangardner/issue/JON-80/remove-redundant-response-assignment-on-404-ghostapierror-mocks)

<!-- generated-by-cyrus -->