### PR TITLE
fix(errors): surface Ghost API error details in MCP responses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,8 @@ Follow these principles when writing code:
    - `logger.js`: Context-aware logging with request correlation
    - `nqlSanitizer.js`: NQL query sanitization (consolidated from memberService and tierService)
    - `imageInputResolver.js`: Resolves image input from URL, local file path (with containment check against `GHOST_MCP_IMAGE_ROOT`), or base64 data
+   - `formatErrorResponse.js`: Builds a consistent `{error, ghost?}` envelope for all MCP tool error responses. **MUST be used for every new MCP error path** — it is the only route through `sanitizeErrorPayload` and therefore the only way error text is guaranteed to be redacted before reaching MCP clients.
+   - `sanitizeErrorPayload.js`: Secret-redaction chokepoint; deep-walks an error envelope and redacts `GHOST_ADMIN_API_KEY`, Ghost-shaped admin key patterns, URL key/token query params, and `Authorization` headers before the payload reaches MCP clients. Called internally by `formatErrorResponse` — do not call directly.
 
 ### Environment Configuration
 

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -321,7 +321,7 @@ const data = validation.data;
 
 ### 3. MCP Error Response Format
 
-All MCP tool catch blocks must call `formatErrorResponse(error, toolName)` from `src/utils/formatErrorResponse.js`. This is the **only** path through the `sanitizeErrorPayload` redaction layer, so bypassing it means secrets can leak to MCP clients.
+All MCP tool catch blocks must call `formatErrorResponse(error, toolName, extra?)` from `src/utils/formatErrorResponse.js`. This is the **only** path through the `sanitizeErrorPayload` redaction layer, so bypassing it means secrets can leak to MCP clients. The optional third arg `extra` is an arbitrary caller-supplied context object (e.g. orphaned-resource details); if provided and non-empty, it is merged into the envelope under a top-level `extra` key and sanitized alongside `error`/`ghost`. A `ZodError` thrown from inside a handler is auto-coerced to a `ValidationError` so the envelope carries the correct `VALIDATION_ERROR` / `400` shape.
 
 **Envelope shape**
 

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -172,17 +172,22 @@ router.post(
 ### MCP Tool with Error Handling
 
 ```javascript
-const tool = new Tool({
-  name: 'create_post',
-  implementation: async (input) => {
+import { formatErrorResponse } from './utils/formatErrorResponse.js';
+
+server.registerTool(
+  'ghost_create_post',
+  { description: '...', inputSchema: createPostSchema },
+  async (input) => {
     try {
       return await createPost(input);
     } catch (error) {
-      return ErrorHandler.formatMCPError(error, 'create_post');
+      return formatErrorResponse(error, 'ghost_create_post');
     }
-  },
-});
+  }
+);
 ```
+
+See the "MCP Error Response Format" section below for the envelope shape and redaction guarantees.
 
 ## Configuration
 
@@ -307,15 +312,20 @@ const data = validation.data;
 
 **Zod Error Response Format:**
 
+Zod validation errors are surfaced via `formatErrorResponse`, which emits a human-readable summary line followed by a fenced JSON block with the canonical envelope. See "MCP Error Response Format" below for the full shape. For a Zod failure, the JSON block looks like:
+
 ```json
 {
-  "content": [
-    {
-      "type": "text",
-      "text": "{\"error\":\"ValidationError\",\"message\":\"Invalid input for ghost_create_post\",\"details\":[{\"field\":\"title\",\"message\":\"Title cannot be empty\"},{\"field\":\"html\",\"message\":\"HTML content cannot be empty\"}]}"
-    }
-  ],
-  "isError": true
+  "error": {
+    "name": "ValidationError",
+    "code": "VALIDATION_ERROR",
+    "message": "ghost_create_post: Validation failed",
+    "statusCode": 400,
+    "errors": [
+      { "field": "title", "message": "Title cannot be empty", "type": "too_small" },
+      { "field": "html", "message": "HTML content cannot be empty", "type": "too_small" }
+    ]
+  }
 }
 ```
 

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -319,7 +319,56 @@ const data = validation.data;
 }
 ```
 
-### 3. XSS Prevention
+### 3. MCP Error Response Format
+
+All MCP tool catch blocks must call `formatErrorResponse(error, toolName)` from `src/utils/formatErrorResponse.js`. This is the **only** path through the `sanitizeErrorPayload` redaction layer, so bypassing it means secrets can leak to MCP clients.
+
+**Envelope shape**
+
+```json
+{
+  "error": {
+    "name": "GhostAPIError",
+    "code": "GHOST_API_ERROR",
+    "message": "Ghost API request failed",
+    "statusCode": 422
+  },
+  "ghost": {
+    "operation": "ghost_create_post",
+    "statusCode": 422,
+    "originalMessage": "Validation failed for field 'title' ..."
+  }
+}
+```
+
+- `error` is always present and contains the normalised error properties (`name`, `code`, `message`, `statusCode`).
+- `ghost` is only present when the thrown error is a `GhostAPIError`; it surfaces Ghost Admin API detail that would otherwise be swallowed.
+- `ghost.originalMessage` is the raw message from the Ghost API response, truncated at **2048 bytes** to prevent oversized payloads.
+
+**Secret redaction**
+
+Before the envelope reaches any MCP client, `sanitizeErrorPayload` deep-walks every string value and redacts:
+
+- The value of `GHOST_ADMIN_API_KEY` (if present in the process environment)
+- Ghost-shaped admin key patterns (`<id>:<secret>` hex strings)
+- `key` and `token` query parameters in URLs
+- `Authorization` header values
+
+`sanitizeErrorPayload` is called internally by `formatErrorResponse`. Do not call it directly or construct your own error envelope — always use `formatErrorResponse`.
+
+**Usage in MCP tool handlers**
+
+```javascript
+import { formatErrorResponse } from './utils/formatErrorResponse.js';
+
+try {
+  return await performOperation(input);
+} catch (error) {
+  return formatErrorResponse(error, 'ghost_create_post');
+}
+```
+
+### 5. XSS Prevention
 
 HTML sanitization is integrated into the Zod schema layer for defense-in-depth:
 
@@ -333,7 +382,7 @@ const sanitizedHtml = htmlContentSchema.parse(userProvidedHtml);
 
 The `htmlContentSchema` uses `sanitize-html` with a strict allowlist of safe tags and attributes. See [Schema Validation](./SCHEMA_VALIDATION.md) for details.
 
-### 4. Rate Limiting
+### 6. Rate Limiting
 
 Prevents abuse and DOS attacks:
 

--- a/src/mcp_server.js
+++ b/src/mcp_server.js
@@ -11,24 +11,6 @@ import crypto from 'crypto';
 import { validateToolInput } from './utils/validation.js';
 import { formatErrorResponse } from './utils/formatErrorResponse.js';
 import { createContextLogger } from './utils/logger.js';
-
-const mcpLogger = createContextLogger('mcp-server');
-
-/**
- * Emit structured log fields for a caught error. Never passes the raw error
- * object to the logger — Ghost SDK errors carry request headers/URLs that
- * include credentials.
- */
-const logToolError = (toolName, error, extra = {}) => {
-  mcpLogger.error(`Tool ${toolName} failed`, {
-    tool: toolName,
-    errorName: error?.name,
-    errorMessage: error?.message,
-    errorCode: error?.code,
-    ghostStatusCode: error?.ghostStatusCode,
-    ...extra,
-  });
-};
 import { trackTempFile, cleanupTempFiles } from './utils/tempFileManager.js';
 import { resolveLocalImagePath, decodeBase64ToTempFile } from './utils/imageInputResolver.js';
 import {
@@ -56,6 +38,24 @@ import {
 
 // Load environment variables
 dotenv.config({ quiet: true });
+
+const mcpLogger = createContextLogger('mcp-server');
+
+/**
+ * Emit structured log fields for a caught error. Never passes the raw error
+ * object to the logger — Ghost SDK errors carry request headers/URLs that
+ * include credentials.
+ */
+const logToolError = (toolName, error, extra = {}) => {
+  mcpLogger.error(`Tool ${toolName} failed`, {
+    tool: toolName,
+    errorName: error?.name,
+    errorMessage: error?.message,
+    errorCode: error?.code,
+    ghostStatusCode: error?.ghostStatusCode,
+    ...extra,
+  });
+};
 
 // Lazy-loaded modules (to avoid Node.js v25 Buffer compatibility issues at startup)
 let ghostService = null;

--- a/src/mcp_server.js
+++ b/src/mcp_server.js
@@ -10,6 +10,25 @@ import os from 'os';
 import crypto from 'crypto';
 import { validateToolInput } from './utils/validation.js';
 import { formatErrorResponse } from './utils/formatErrorResponse.js';
+import { createContextLogger } from './utils/logger.js';
+
+const mcpLogger = createContextLogger('mcp-server');
+
+/**
+ * Emit structured log fields for a caught error. Never passes the raw error
+ * object to the logger — Ghost SDK errors carry request headers/URLs that
+ * include credentials.
+ */
+const logToolError = (toolName, error, extra = {}) => {
+  mcpLogger.error(`Tool ${toolName} failed`, {
+    tool: toolName,
+    errorName: error?.name,
+    errorMessage: error?.message,
+    errorCode: error?.code,
+    ghostStatusCode: error?.ghostStatusCode,
+    ...extra,
+  });
+};
 import { trackTempFile, cleanupTempFiles } from './utils/tempFileManager.js';
 import { resolveLocalImagePath, decodeBase64ToTempFile } from './utils/imageInputResolver.js';
 import {
@@ -110,7 +129,7 @@ const withErrorHandling = (toolName, schema, handler) => {
       await loadServices();
       return await handler(validation.data);
     } catch (error) {
-      console.error(`Error in ${toolName}:`, error);
+      logToolError(toolName, error);
       return formatErrorResponse(error, toolName);
     }
   };
@@ -441,7 +460,7 @@ server.registerTool(
       if (uploadResult.ref) result.ref = uploadResult.ref;
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
     } catch (error) {
-      console.error(`Error in ghost_upload_image:`, error);
+      logToolError('ghost_upload_image', error);
       return formatErrorResponse(error, 'ghost_upload_image');
     }
   }
@@ -488,7 +507,7 @@ server.registerTool(
       uploadedRef = uploadResult.ref;
       altText = finalAltText;
     } catch (error) {
-      console.error(`ghost_set_feature_image: upload failed`, error);
+      logToolError('ghost_set_feature_image', error, { phase: 'upload' });
       return formatErrorResponse(error, 'ghost_set_feature_image');
     }
 
@@ -517,7 +536,10 @@ server.registerTool(
         ],
       };
     } catch (error) {
-      console.error(`ghost_set_feature_image: update failed (orphaned ${uploadedUrl})`, error);
+      logToolError('ghost_set_feature_image', error, {
+        phase: 'update',
+        orphanedUrl: uploadedUrl,
+      });
       return formatErrorResponse(error, 'ghost_set_feature_image', {
         orphanedImage: { url: uploadedUrl, ref: uploadedRef, alt: altText },
         hint: 'Ghost does not expose a delete-image endpoint; reuse this URL or leave it orphaned.',

--- a/src/mcp_server.js
+++ b/src/mcp_server.js
@@ -8,8 +8,8 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import crypto from 'crypto';
-import { ValidationError } from './errors/index.js';
 import { validateToolInput } from './utils/validation.js';
+import { formatErrorResponse } from './utils/formatErrorResponse.js';
 import { trackTempFile, cleanupTempFiles } from './utils/tempFileManager.js';
 import { resolveLocalImagePath, decodeBase64ToTempFile } from './utils/imageInputResolver.js';
 import {
@@ -99,7 +99,6 @@ const escapeNqlValue = (value) => {
  * @returns {Function} Wrapped async handler for server.registerTool
  */
 const withErrorHandling = (toolName, schema, handler) => {
-  const zodContext = toolName.replace('ghost_', '').replace(/_/g, ' ');
   return async (rawInput) => {
     console.error(`Executing tool: ${toolName}`);
     const validation = validateToolInput(schema, rawInput, toolName);
@@ -112,17 +111,7 @@ const withErrorHandling = (toolName, schema, handler) => {
       return await handler(validation.data);
     } catch (error) {
       console.error(`Error in ${toolName}:`, error);
-      if (error.name === 'ZodError') {
-        const validationError = ValidationError.fromZod(error, zodContext);
-        return {
-          content: [{ type: 'text', text: JSON.stringify(validationError.toJSON(), null, 2) }],
-          isError: true,
-        };
-      }
-      return {
-        content: [{ type: 'text', text: `Error in ${toolName}: ${error.message}` }],
-        isError: true,
-      };
+      return formatErrorResponse(error, toolName);
     }
   };
 };
@@ -453,10 +442,7 @@ server.registerTool(
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
     } catch (error) {
       console.error(`Error in ghost_upload_image:`, error);
-      return {
-        content: [{ type: 'text', text: `Error uploading image: ${error.message}` }],
-        isError: true,
-      };
+      return formatErrorResponse(error, 'ghost_upload_image');
     }
   }
 );
@@ -503,10 +489,7 @@ server.registerTool(
       altText = finalAltText;
     } catch (error) {
       console.error(`ghost_set_feature_image: upload failed`, error);
-      return {
-        content: [{ type: 'text', text: `Upload failed: ${error.message}` }],
-        isError: true,
-      };
+      return formatErrorResponse(error, 'ghost_set_feature_image');
     }
 
     const updatePayload = {
@@ -535,23 +518,17 @@ server.registerTool(
       };
     } catch (error) {
       console.error(`ghost_set_feature_image: update failed (orphaned ${uploadedUrl})`, error);
-      return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(
-              {
-                error: `Upload succeeded but ${type} update failed: ${error.message}`,
-                orphanedImage: { url: uploadedUrl, ref: uploadedRef, alt: altText },
-                hint: 'Ghost does not expose a delete-image endpoint; reuse this URL or leave it orphaned.',
-              },
-              null,
-              2
-            ),
-          },
-        ],
-        isError: true,
-      };
+      const response = formatErrorResponse(error, 'ghost_set_feature_image');
+      const orphanInfo = JSON.stringify(
+        {
+          orphanedImage: { url: uploadedUrl, ref: uploadedRef, alt: altText },
+          hint: 'Ghost does not expose a delete-image endpoint; reuse this URL or leave it orphaned.',
+        },
+        null,
+        2
+      );
+      response.content[0].text += `\n\n${orphanInfo}`;
+      return response;
     }
   }
 );

--- a/src/mcp_server.js
+++ b/src/mcp_server.js
@@ -518,17 +518,10 @@ server.registerTool(
       };
     } catch (error) {
       console.error(`ghost_set_feature_image: update failed (orphaned ${uploadedUrl})`, error);
-      const response = formatErrorResponse(error, 'ghost_set_feature_image');
-      const orphanInfo = JSON.stringify(
-        {
-          orphanedImage: { url: uploadedUrl, ref: uploadedRef, alt: altText },
-          hint: 'Ghost does not expose a delete-image endpoint; reuse this URL or leave it orphaned.',
-        },
-        null,
-        2
-      );
-      response.content[0].text += `\n\n${orphanInfo}`;
-      return response;
+      return formatErrorResponse(error, 'ghost_set_feature_image', {
+        orphanedImage: { url: uploadedUrl, ref: uploadedRef, alt: altText },
+        hint: 'Ghost does not expose a delete-image endpoint; reuse this URL or leave it orphaned.',
+      });
     }
   }
 );

--- a/src/utils/__tests__/formatErrorResponse.test.js
+++ b/src/utils/__tests__/formatErrorResponse.test.js
@@ -92,4 +92,67 @@ describe('formatErrorResponse', () => {
     expect(envelope.error.code).toBe('NOT_FOUND');
     expect(envelope).not.toHaveProperty('ghost');
   });
+
+  describe('extra context', () => {
+    it('includes and sanitizes extra context when provided', () => {
+      const extra = {
+        orphanedImage: { url: 'https://cdn.example/img.jpg?key=LEAK_ME_XYZ', ref: 'r1' },
+      };
+      const response = formatErrorResponse(new Error('boom'), 'ghost_set_feature_image', extra);
+      const envelope = parseJsonBlock(response.content[0].text);
+      expect(envelope.extra).toBeDefined();
+      expect(envelope.extra.orphanedImage.url).toContain('key=[REDACTED]');
+      expect(response.content[0].text).not.toContain('LEAK_ME_XYZ');
+    });
+
+    it('omits extra key entirely when arg is not provided', () => {
+      const envelope = parseJsonBlock(
+        formatErrorResponse(new Error('boom'), 'ghost_update_post').content[0].text
+      );
+      expect(envelope).not.toHaveProperty('extra');
+    });
+
+    it('omits extra key when arg is empty object (no empty-object leak)', () => {
+      const envelope = parseJsonBlock(
+        formatErrorResponse(new Error('boom'), 'ghost_update_post', {}).content[0].text
+      );
+      expect(envelope).not.toHaveProperty('extra');
+    });
+
+    it('combines error, ghost, and extra when all apply', () => {
+      const err = new GhostAPIError('posts.edit', 'bad', 422);
+      const envelope = parseJsonBlock(
+        formatErrorResponse(err, 'ghost_set_feature_image', { orphanedImage: { url: 'x' } })
+          .content[0].text
+      );
+      expect(envelope.error).toBeDefined();
+      expect(envelope.ghost).toBeDefined();
+      expect(envelope.extra).toBeDefined();
+    });
+  });
+
+  describe('ZodError coercion', () => {
+    it('coerces ZodError-shaped input to VALIDATION_ERROR / 400 envelope', () => {
+      const zodLike = Object.assign(new Error('zod'), {
+        name: 'ZodError',
+        issues: [{ path: ['purpose'], message: 'Invalid enum value', code: 'invalid_enum_value' }],
+      });
+      const envelope = parseJsonBlock(
+        formatErrorResponse(zodLike, 'ghost_upload_image').content[0].text
+      );
+      expect(envelope.error.code).toBe('VALIDATION_ERROR');
+      expect(envelope.error.statusCode).toBe(400);
+      expect(envelope.error.errors).toEqual([
+        { field: 'purpose', message: 'Invalid enum value', type: 'invalid_enum_value' },
+      ]);
+    });
+
+    it('does not coerce a non-ZodError error that happens to have an issues field', () => {
+      const notZod = Object.assign(new Error('unrelated'), { issues: [] });
+      const envelope = parseJsonBlock(
+        formatErrorResponse(notZod, 'ghost_update_post').content[0].text
+      );
+      expect(envelope.error.code).toBe('UNKNOWN');
+    });
+  });
 });

--- a/src/utils/__tests__/formatErrorResponse.test.js
+++ b/src/utils/__tests__/formatErrorResponse.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { formatErrorResponse } from '../formatErrorResponse.js';
+import { GhostAPIError, ValidationError, NotFoundError } from '../../errors/index.js';
+
+function parseJsonBlock(text) {
+  const match = text.match(/```json\n([\s\S]+?)\n```/);
+  expect(match, `no JSON block in: ${text}`).toBeTruthy();
+  return JSON.parse(match[1]);
+}
+
+describe('formatErrorResponse', () => {
+  const originalEnv = process.env.GHOST_ADMIN_API_KEY;
+
+  beforeEach(() => {
+    process.env.GHOST_ADMIN_API_KEY = '';
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.GHOST_ADMIN_API_KEY;
+    else process.env.GHOST_ADMIN_API_KEY = originalEnv;
+  });
+
+  it('returns consistent envelope with error key for generic Error (no ghost key)', () => {
+    const response = formatErrorResponse(new Error('boom'), 'ghost_get_posts');
+    expect(response.isError).toBe(true);
+    expect(response.content[0].type).toBe('text');
+    const envelope = parseJsonBlock(response.content[0].text);
+    expect(envelope.error).toBeDefined();
+    expect(envelope.error.message).toBe('boom');
+    expect(envelope).not.toHaveProperty('ghost');
+    expect(response.content[0].text).toContain('Error in ghost_get_posts: boom');
+  });
+
+  it('includes gated ghost sub-object for GhostAPIError', () => {
+    const err = new GhostAPIError('posts.edit', 'Title is required', 422);
+    const response = formatErrorResponse(err, 'ghost_update_post');
+    const envelope = parseJsonBlock(response.content[0].text);
+    expect(envelope.error.name).toBe('GhostAPIError');
+    expect(envelope.error.code).toBe('GHOST_VALIDATION_ERROR');
+    expect(envelope.ghost).toBeDefined();
+    expect(envelope.ghost.operation).toBe('posts.edit');
+    expect(envelope.ghost.statusCode).toBe(422);
+    expect(envelope.ghost.originalMessage).toBe('Title is required');
+    expect(response.content[0].text).toContain('422');
+    expect(response.content[0].text).toContain('posts.edit');
+    expect(response.content[0].text).toContain('Title is required');
+  });
+
+  it('uses raw ghostStatusCode (not remapped statusCode) in ghost envelope', () => {
+    const err = new GhostAPIError('posts.edit', 'bad', 422);
+    // GhostAPIError remaps 422 -> 400 for .statusCode; ghost.statusCode must be 422
+    expect(err.statusCode).toBe(400);
+    expect(err.ghostStatusCode).toBe(422);
+    const envelope = parseJsonBlock(formatErrorResponse(err, 'ghost_update_post').content[0].text);
+    expect(envelope.ghost.statusCode).toBe(422);
+    expect(envelope.error.statusCode).toBe(400);
+  });
+
+  it('does not leak GHOST_ADMIN_API_KEY in surfaced response', () => {
+    process.env.GHOST_ADMIN_API_KEY = 'plaintext-admin-key-xyz';
+    const err = new GhostAPIError(
+      'posts.edit',
+      'Ghost complained: token plaintext-admin-key-xyz invalid',
+      401
+    );
+    const response = formatErrorResponse(err, 'ghost_update_post');
+    expect(response.content[0].text).not.toContain('plaintext-admin-key-xyz');
+    expect(response.content[0].text).toContain('[REDACTED]');
+  });
+
+  it('does not leak Ghost-shaped admin key pattern in originalMessage', () => {
+    const fakeKey = `${'1'.repeat(24)}:${'2'.repeat(64)}`;
+    const err = new GhostAPIError('posts.edit', `failed with ${fakeKey}`, 401);
+    const response = formatErrorResponse(err, 'ghost_update_post');
+    expect(response.content[0].text).not.toContain(fakeKey);
+  });
+
+  it('produces envelope for ValidationError (no ghost key)', () => {
+    const err = new ValidationError('Validation failed', [
+      { field: 'title', message: 'required', type: 'invalid_type' },
+    ]);
+    const response = formatErrorResponse(err, 'ghost_update_post');
+    const envelope = parseJsonBlock(response.content[0].text);
+    expect(envelope.error.code).toBe('VALIDATION_ERROR');
+    expect(envelope).not.toHaveProperty('ghost');
+  });
+
+  it('produces envelope for NotFoundError (no ghost key)', () => {
+    const err = new NotFoundError('Post', 'abc');
+    const response = formatErrorResponse(err, 'ghost_get_post');
+    const envelope = parseJsonBlock(response.content[0].text);
+    expect(envelope.error.code).toBe('NOT_FOUND');
+    expect(envelope).not.toHaveProperty('ghost');
+  });
+});

--- a/src/utils/__tests__/sanitizeErrorPayload.test.js
+++ b/src/utils/__tests__/sanitizeErrorPayload.test.js
@@ -60,6 +60,38 @@ describe('sanitizeErrorPayload', () => {
     expect(out.error.message).toContain('[REDACTED]');
   });
 
+  it('redacts every value in a multi-value Cookie header', () => {
+    const out = sanitizeErrorPayload({
+      error: { message: 'Cookie: a=first; b=SECRET_SESSION; c=third' },
+    });
+    expect(out.error.message).not.toContain('SECRET_SESSION');
+    expect(out.error.message).not.toContain('a=first');
+    expect(out.error.message).not.toContain('c=third');
+    expect(out.error.message).toContain('Cookie: [REDACTED]');
+  });
+
+  it('redacts Set-Cookie value but preserves attributes (HttpOnly, Secure, Path)', () => {
+    const out = sanitizeErrorPayload({
+      error: { message: 'Set-Cookie: sess=TOKEN_XYZ; HttpOnly; Secure; Path=/' },
+    });
+    expect(out.error.message).not.toContain('TOKEN_XYZ');
+    expect(out.error.message).toContain('Set-Cookie: [REDACTED]');
+    expect(out.error.message).toContain('HttpOnly');
+    expect(out.error.message).toContain('Secure');
+  });
+
+  it('redacts secrets inside string elements of arrays (truncation flag no longer needed)', () => {
+    const out = sanitizeErrorPayload({
+      ghost: {
+        originalMessage: ['https://x/y?key=LEAKED_1', 'https://x/y?token=LEAKED_2'],
+      },
+    });
+    expect(JSON.stringify(out)).not.toContain('LEAKED_1');
+    expect(JSON.stringify(out)).not.toContain('LEAKED_2');
+    expect(out.ghost.originalMessage[0]).toContain('key=[REDACTED]');
+    expect(out.ghost.originalMessage[1]).toContain('token=[REDACTED]');
+  });
+
   it('leaves benign content untouched', () => {
     const input = {
       error: { message: 'Title is required', code: 'GHOST_VALIDATION_ERROR', statusCode: 400 },

--- a/src/utils/__tests__/sanitizeErrorPayload.test.js
+++ b/src/utils/__tests__/sanitizeErrorPayload.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { sanitizeErrorPayload } from '../sanitizeErrorPayload.js';
+
+describe('sanitizeErrorPayload', () => {
+  const originalEnv = process.env.GHOST_ADMIN_API_KEY;
+
+  beforeEach(() => {
+    process.env.GHOST_ADMIN_API_KEY = '';
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.GHOST_ADMIN_API_KEY;
+    } else {
+      process.env.GHOST_ADMIN_API_KEY = originalEnv;
+    }
+  });
+
+  it('redacts GHOST_ADMIN_API_KEY when it appears verbatim in a nested string', () => {
+    process.env.GHOST_ADMIN_API_KEY = 'super-secret-env-key-value';
+    const input = {
+      error: { message: 'Leaked super-secret-env-key-value in text' },
+      ghost: { originalMessage: 'also super-secret-env-key-value here' },
+    };
+    const out = sanitizeErrorPayload(input);
+    expect(out.error.message).not.toContain('super-secret-env-key-value');
+    expect(out.error.message).toContain('[REDACTED]');
+    expect(out.ghost.originalMessage).not.toContain('super-secret-env-key-value');
+  });
+
+  it('redacts Ghost-shaped admin key literal embedded in text', () => {
+    const key = `${'a'.repeat(24)}:${'b'.repeat(64)}`;
+    const out = sanitizeErrorPayload({
+      error: { message: `Bad auth with ${key} failed` },
+    });
+    expect(out.error.message).not.toContain(key);
+    expect(out.error.message).toContain('[REDACTED]');
+  });
+
+  it('redacts key= token= and access_token= query params on URLs', () => {
+    const out = sanitizeErrorPayload({
+      error: { message: 'GET https://ghost.example/admin?key=abc123&other=fine' },
+      ghost: {
+        originalMessage: 'https://x/y?token=xyz and https://x/y?access_token=qqq',
+      },
+    });
+    expect(out.error.message).toContain('key=[REDACTED]');
+    expect(out.error.message).toContain('other=fine');
+    expect(out.ghost.originalMessage).toContain('token=[REDACTED]');
+    expect(out.ghost.originalMessage).toContain('access_token=[REDACTED]');
+  });
+
+  it('redacts Authorization / Cookie header-style substrings', () => {
+    const out = sanitizeErrorPayload({
+      error: { message: 'Authorization: Bearer abc.def.ghi and Cookie: sess=xyz' },
+    });
+    expect(out.error.message).not.toContain('abc.def.ghi');
+    expect(out.error.message).not.toContain('sess=xyz');
+    expect(out.error.message).toContain('Authorization');
+    expect(out.error.message).toContain('[REDACTED]');
+  });
+
+  it('leaves benign content untouched', () => {
+    const input = {
+      error: { message: 'Title is required', code: 'GHOST_VALIDATION_ERROR', statusCode: 400 },
+      ghost: {
+        operation: 'posts.edit',
+        statusCode: 422,
+        originalMessage: 'Post title cannot be blank',
+      },
+    };
+    const out = sanitizeErrorPayload(input);
+    expect(out).toEqual(input);
+  });
+
+  it('truncates long originalMessage', () => {
+    const longMsg = 'x'.repeat(5000);
+    const out = sanitizeErrorPayload({
+      ghost: { originalMessage: longMsg },
+    });
+    expect(out.ghost.originalMessage.length).toBeLessThan(longMsg.length);
+    expect(out.ghost.originalMessage).toContain('[truncated]');
+  });
+
+  it('does not redact env key when env var is empty', () => {
+    process.env.GHOST_ADMIN_API_KEY = '';
+    const out = sanitizeErrorPayload({ error: { message: 'harmless text' } });
+    expect(out.error.message).toBe('harmless text');
+  });
+
+  it('does not mutate the input object', () => {
+    process.env.GHOST_ADMIN_API_KEY = 'SECRET';
+    const input = { error: { message: 'contains SECRET' } };
+    const snapshot = JSON.parse(JSON.stringify(input));
+    sanitizeErrorPayload(input);
+    expect(input).toEqual(snapshot);
+  });
+});

--- a/src/utils/__tests__/validation.test.js
+++ b/src/utils/__tests__/validation.test.js
@@ -54,11 +54,14 @@ describe('validateToolInput', () => {
       const result = validateToolInput(testSchema, { name: '' }, 'test_tool');
 
       expect(result.success).toBe(false);
-      const errorObj = JSON.parse(result.errorResponse.content[0].text);
-      expect(errorObj.name).toBe('ValidationError');
-      expect(errorObj.code).toBe('VALIDATION_ERROR');
-      expect(errorObj.statusCode).toBe(400);
-      expect(errorObj.message).toContain('Validation failed');
+      const text = result.errorResponse.content[0].text;
+      const jsonMatch = text.match(/```json\n([\s\S]+?)\n```/);
+      expect(jsonMatch).toBeTruthy();
+      const envelope = JSON.parse(jsonMatch[1]);
+      expect(envelope.error.name).toBe('ValidationError');
+      expect(envelope.error.code).toBe('VALIDATION_ERROR');
+      expect(envelope.error.statusCode).toBe(400);
+      expect(envelope.error.message).toContain('Validation failed');
     });
   });
 
@@ -141,8 +144,11 @@ describe('validateToolInput', () => {
 
       expect(result.success).toBe(false);
       expect(result.errorResponse.isError).toBe(true);
-      const errorObj = JSON.parse(result.errorResponse.content[0].text);
-      expect(errorObj.code).toBe('VALIDATION_ERROR');
+      const text = result.errorResponse.content[0].text;
+      const jsonMatch = text.match(/```json\n([\s\S]+?)\n```/);
+      expect(jsonMatch).toBeTruthy();
+      const envelope = JSON.parse(jsonMatch[1]);
+      expect(envelope.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('should pass validation when refinement is satisfied', () => {

--- a/src/utils/formatErrorResponse.js
+++ b/src/utils/formatErrorResponse.js
@@ -1,0 +1,51 @@
+import { BaseError, GhostAPIError } from '../errors/index.js';
+import { sanitizeErrorPayload } from './sanitizeErrorPayload.js';
+
+/**
+ * Builds an MCP tool error response with a consistent envelope shape.
+ * All errors produce `{ error: {...} }`; GhostAPIError additionally includes
+ * a gated `ghost` sub-object with Ghost-specific diagnostic fields.
+ * The envelope is passed through sanitizeErrorPayload before emission.
+ *
+ * @param {Error} error - The caught error.
+ * @param {string} toolName - MCP tool name for the human-readable summary line.
+ * @returns {{content: {type: string, text: string}[], isError: true}}
+ */
+export function formatErrorResponse(error, toolName) {
+  const base =
+    error instanceof BaseError
+      ? error.toJSON()
+      : {
+          name: error?.name || 'Error',
+          message: error?.message || String(error),
+          code: 'UNKNOWN',
+          statusCode: 500,
+        };
+
+  const envelope = { error: base };
+
+  if (error instanceof GhostAPIError) {
+    envelope.ghost = {
+      operation: error.operation,
+      statusCode: error.ghostStatusCode,
+      // error.originalError is already a string (coerced by ExternalServiceError constructor);
+      // coerce again defensively so the sanitizer always receives a string, not an Error object.
+      originalMessage:
+        typeof error.originalError === 'string'
+          ? error.originalError
+          : (error.originalError?.message ?? String(error.originalError)),
+    };
+  }
+
+  const sanitized = sanitizeErrorPayload(envelope);
+  const summary = sanitized.ghost
+    ? `Error in ${toolName}: ${sanitized.error.name} [${sanitized.ghost.statusCode ?? '?'} ${sanitized.error.code}] ${sanitized.ghost.operation ?? '?'}: ${sanitized.ghost.originalMessage ?? sanitized.error.message}`
+    : `Error in ${toolName}: ${sanitized.error.message}`;
+
+  const body = `${summary}\n\n\`\`\`json\n${JSON.stringify(sanitized, null, 2)}\n\`\`\``;
+
+  return {
+    content: [{ type: 'text', text: body }],
+    isError: true,
+  };
+}

--- a/src/utils/formatErrorResponse.js
+++ b/src/utils/formatErrorResponse.js
@@ -1,40 +1,52 @@
-import { BaseError, GhostAPIError } from '../errors/index.js';
+import { BaseError, GhostAPIError, ValidationError } from '../errors/index.js';
 import { sanitizeErrorPayload } from './sanitizeErrorPayload.js';
 
 /**
  * Builds an MCP tool error response with a consistent envelope shape.
  * All errors produce `{ error: {...} }`; GhostAPIError additionally includes
- * a gated `ghost` sub-object with Ghost-specific diagnostic fields.
- * The envelope is passed through sanitizeErrorPayload before emission.
+ * a gated `ghost` sub-object with Ghost-specific diagnostic fields. Callers
+ * may pass an optional `extra` object whose contents will be merged into the
+ * envelope under an `extra` key and sanitized alongside the rest.
  *
  * @param {Error} error - The caught error.
  * @param {string} toolName - MCP tool name for the human-readable summary line.
+ * @param {object} [extra] - Optional caller-supplied context; sanitized with the envelope.
  * @returns {{content: {type: string, text: string}[], isError: true}}
  */
-export function formatErrorResponse(error, toolName) {
+export function formatErrorResponse(error, toolName, extra) {
+  // Duck-type ZodError so we don't couple this module to the zod runtime.
+  const normalized =
+    error?.name === 'ZodError' && Array.isArray(error.issues)
+      ? ValidationError.fromZod(error, toolName)
+      : error;
+
   const base =
-    error instanceof BaseError
-      ? error.toJSON()
+    normalized instanceof BaseError
+      ? normalized.toJSON()
       : {
-          name: error?.name || 'Error',
-          message: error?.message || String(error),
+          name: normalized?.name || 'Error',
+          message: normalized?.message || String(normalized),
           code: 'UNKNOWN',
           statusCode: 500,
         };
 
   const envelope = { error: base };
 
-  if (error instanceof GhostAPIError) {
+  if (normalized instanceof GhostAPIError) {
     envelope.ghost = {
-      operation: error.operation,
-      statusCode: error.ghostStatusCode,
-      // error.originalError is already a string (coerced by ExternalServiceError constructor);
+      operation: normalized.operation,
+      statusCode: normalized.ghostStatusCode,
+      // normalized.originalError is already a string (coerced by ExternalServiceError constructor);
       // coerce again defensively so the sanitizer always receives a string, not an Error object.
       originalMessage:
-        typeof error.originalError === 'string'
-          ? error.originalError
-          : (error.originalError?.message ?? String(error.originalError)),
+        typeof normalized.originalError === 'string'
+          ? normalized.originalError
+          : (normalized.originalError?.message ?? String(normalized.originalError)),
     };
+  }
+
+  if (extra && typeof extra === 'object' && Object.keys(extra).length > 0) {
+    envelope.extra = extra;
   }
 
   const sanitized = sanitizeErrorPayload(envelope);

--- a/src/utils/sanitizeErrorPayload.js
+++ b/src/utils/sanitizeErrorPayload.js
@@ -5,7 +5,14 @@
 
 const GHOST_KEY_PATTERN = /[0-9a-f]{24}:[0-9a-f]{64}/gi;
 const URL_SECRET_QS_PATTERN = /([?&](?:key|token|access_token)=)[^&\s"']+/gi;
-const AUTH_HEADER_PATTERN = /(Authorization|Cookie|Set-Cookie)\s*[:=]\s*[^\r\n,;]+/gi;
+// Authorization / Set-Cookie values stop at ';' (Set-Cookie attributes like
+// HttpOnly/Secure are not secrets). A bare `Cookie` header can contain multiple
+// `name=value` pairs separated by ';' — all of which may be session tokens — so
+// it gets a separate, greedier pattern that stops only at end-of-line.
+const AUTH_HEADER_PATTERN = /(Authorization|Set-Cookie)\s*[:=]\s*[^\r\n,;]+/gi;
+// Negative look-behind so this pattern matches a bare `Cookie:` header but not
+// the `Cookie` substring inside `Set-Cookie:` (handled by AUTH_HEADER_PATTERN).
+const COOKIE_HEADER_PATTERN = /(?<!Set-)(Cookie)\s*[:=]\s*[^\r\n]+/gi;
 const REDACTED = '[REDACTED]';
 const ORIGINAL_MESSAGE_MAX_BYTES = 2048;
 
@@ -18,6 +25,7 @@ function redactString(value, envKey) {
   out = out.replace(GHOST_KEY_PATTERN, REDACTED);
   out = out.replace(URL_SECRET_QS_PATTERN, `$1${REDACTED}`);
   out = out.replace(AUTH_HEADER_PATTERN, `$1: ${REDACTED}`);
+  out = out.replace(COOKIE_HEADER_PATTERN, `$1: ${REDACTED}`);
   return out;
 }
 
@@ -28,19 +36,18 @@ function truncate(value, maxBytes) {
   return `${Buffer.from(value, 'utf8').subarray(0, maxBytes).toString('utf8')}…[truncated]`;
 }
 
-function walk(node, envKey, isOriginalMessage = false) {
+function walk(node, envKey) {
   if (node === null || node === undefined) return node;
-  if (typeof node === 'string') {
-    const redacted = redactString(node, envKey);
-    return isOriginalMessage ? truncate(redacted, ORIGINAL_MESSAGE_MAX_BYTES) : redacted;
-  }
-  if (Array.isArray(node)) {
-    return node.map((item) => walk(item, envKey));
-  }
+  if (typeof node === 'string') return redactString(node, envKey);
+  if (Array.isArray(node)) return node.map((item) => walk(item, envKey));
   if (typeof node === 'object') {
     const result = {};
     for (const [k, v] of Object.entries(node)) {
-      result[k] = walk(v, envKey, k === 'originalMessage');
+      const walked = walk(v, envKey);
+      result[k] =
+        k === 'originalMessage' && typeof walked === 'string'
+          ? truncate(walked, ORIGINAL_MESSAGE_MAX_BYTES)
+          : walked;
     }
     return result;
   }

--- a/src/utils/sanitizeErrorPayload.js
+++ b/src/utils/sanitizeErrorPayload.js
@@ -1,0 +1,60 @@
+/**
+ * Sole chokepoint for sanitizing error payloads surfaced to MCP clients.
+ * Walks the envelope and replaces values that could leak credentials.
+ */
+
+const GHOST_KEY_PATTERN = /[0-9a-f]{24}:[0-9a-f]{64}/gi;
+const URL_SECRET_QS_PATTERN = /([?&](?:key|token|access_token)=)[^&\s"']+/gi;
+const AUTH_HEADER_PATTERN = /(Authorization|Cookie|Set-Cookie)\s*[:=]\s*[^\r\n,;]+/gi;
+const REDACTED = '[REDACTED]';
+const ORIGINAL_MESSAGE_MAX_BYTES = 2048;
+
+function redactString(value, envKey) {
+  if (typeof value !== 'string' || value.length === 0) return value;
+  let out = value;
+  if (envKey) {
+    out = out.replaceAll(envKey, REDACTED);
+  }
+  out = out.replace(GHOST_KEY_PATTERN, REDACTED);
+  out = out.replace(URL_SECRET_QS_PATTERN, `$1${REDACTED}`);
+  out = out.replace(AUTH_HEADER_PATTERN, `$1: ${REDACTED}`);
+  return out;
+}
+
+function truncate(value, maxBytes) {
+  if (typeof value !== 'string') return value;
+  if (Buffer.byteLength(value, 'utf8') <= maxBytes) return value;
+  // Slice by bytes (not chars) to honour the byte limit even for multibyte content.
+  return `${Buffer.from(value, 'utf8').subarray(0, maxBytes).toString('utf8')}…[truncated]`;
+}
+
+function walk(node, envKey, isOriginalMessage = false) {
+  if (node === null || node === undefined) return node;
+  if (typeof node === 'string') {
+    const redacted = redactString(node, envKey);
+    return isOriginalMessage ? truncate(redacted, ORIGINAL_MESSAGE_MAX_BYTES) : redacted;
+  }
+  if (Array.isArray(node)) {
+    return node.map((item) => walk(item, envKey));
+  }
+  if (typeof node === 'object') {
+    const result = {};
+    for (const [k, v] of Object.entries(node)) {
+      result[k] = walk(v, envKey, k === 'originalMessage');
+    }
+    return result;
+  }
+  return node;
+}
+
+/**
+ * Deep-walks an error envelope and redacts known secret patterns.
+ * Non-destructive: returns a new object; does not mutate input.
+ *
+ * @param {object} envelope - Error envelope object.
+ * @returns {object} Sanitized envelope.
+ */
+export function sanitizeErrorPayload(envelope) {
+  const envKey = process.env.GHOST_ADMIN_API_KEY || '';
+  return walk(envelope, envKey);
+}

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -3,6 +3,7 @@
  * Provides explicit Zod validation to ensure input is validated at handler entry points.
  */
 import { ValidationError } from '../errors/index.js';
+import { formatErrorResponse } from './formatErrorResponse.js';
 
 /**
  * Validates tool input against a Zod schema and returns a structured result.
@@ -18,10 +19,7 @@ export const validateToolInput = (schema, input, toolName) => {
     const error = ValidationError.fromZod(result.error, toolName);
     return {
       success: false,
-      errorResponse: {
-        content: [{ type: 'text', text: JSON.stringify(error.toJSON(), null, 2) }],
-        isError: true,
-      },
+      errorResponse: formatErrorResponse(error, toolName),
     };
   }
   return { success: true, data: result.data };


### PR DESCRIPTION
## Summary
- `GhostAPIError` details were swallowed by `ExternalServiceError`'s hardcoded message; every Ghost failure surfaced as `"External service error: Ghost API"`, blocking diagnosis of real failures like the reporter's `ghost_update_post` issue.
- Adds `formatErrorResponse` (consistent `{error, ghost?}` envelope) and `sanitizeErrorPayload` (single redaction chokepoint for `GHOST_ADMIN_API_KEY`, Ghost-shaped admin key patterns, URL key/token query params, and auth headers). All MCP tool catch blocks — including `ghost_upload_image` and `ghost_set_feature_image` — now route through it.
- `ghost` sub-object is gated to `GhostAPIError` and carries raw `ghostStatusCode` + truncated `originalMessage`; non-Ghost errors get the envelope without it.

## Test plan
- [x] `npx vitest run` — 1378 tests pass
- [x] `npm run lint` — clean
- [x] New unit tests: secret redaction (env key, Ghost key pattern, URL params, auth headers), envelope shape, gated `ghost` key, raw vs remapped status code, leak test with `GHOST_ADMIN_API_KEY` planted in Ghost error
- [ ] Manual MCP Inspector: trigger a Ghost validation error and confirm envelope surfaces `ghost.statusCode` + `originalMessage`
- [ ] Manual leak check: grep responses for first 8 chars of `GHOST_ADMIN_API_KEY` — zero hits