### PR TITLE
refactor(errors): address PR #166 review feedback

### DIFF
--- a/src/utils/__tests__/logger.test.js
+++ b/src/utils/__tests__/logger.test.js
@@ -32,6 +32,14 @@ describe('logger', () => {
       // Winston writes to console._stdout/_stderr (Node aliases for
       // process.stdout/stderr, captured at logger construction). Spy on the
       // same references winston uses so the hook lines up with the write.
+      // These are Node internals — fail loudly if they ever disappear so the
+      // test cannot silently turn into a no-op when the assumption breaks.
+      if (!console._stdout || !console._stderr) {
+        throw new Error(
+          'console._stdout/_stderr unavailable; logger transport-routing test ' +
+            'assumptions broken — winston uses these refs for its Console transport.'
+        );
+      }
       stdoutSpy = vi.spyOn(console._stdout, 'write').mockImplementation(() => true);
       stderrSpy = vi.spyOn(console._stderr, 'write').mockImplementation(() => true);
     });

--- a/src/utils/__tests__/sanitizeErrorPayload.test.js
+++ b/src/utils/__tests__/sanitizeErrorPayload.test.js
@@ -124,14 +124,25 @@ describe('sanitizeErrorPayload', () => {
     expect(out.error.message).toContain('[truncated]');
   });
 
-  it('redacts before truncation so sliced content cannot leak a secret prefix', () => {
-    // Secret placed near the END of a 5000-byte string, AFTER the 4 KB cap.
-    // redactString runs first during walk(); truncate runs on the redacted text.
-    const secret = `${'a'.repeat(24)}:${'b'.repeat(64)}`;
-    const msg = 'x'.repeat(4900) + secret;
+  it('redacts BEFORE truncating so secrets spanning the cap boundary cannot leak a prefix', () => {
+    // Place a 89-byte Ghost-shaped admin key so it STRADDLES the 4096-byte
+    // generic cap (starts at 4050, ends at 4139). The ordering matters only
+    // for boundary-spanning values:
+    //   redact-first → full pattern matches, entire secret becomes [REDACTED]
+    //     before truncation; no prefix of the secret remains in the output.
+    //   truncate-first → first 4096 bytes keep a 46-byte PREFIX of the secret;
+    //     GHOST_KEY_PATTERN requires the full 89 chars to match, so the
+    //     partial prefix slips past redaction and leaks.
+    const secret = `${'a'.repeat(24)}:${'b'.repeat(64)}`; // 89 bytes
+    const msg = 'x'.repeat(4050) + secret; // 4139 bytes — boundary at 4096 cuts the secret
     const out = sanitizeErrorPayload({ error: { message: msg } });
-    // Secret must be redacted regardless of whether it fell on the truncated side.
     expect(out.error.message).not.toContain(secret);
+    // The partial prefix that truncate-first would leave behind. If this
+    // appears in the output, redaction ran AFTER truncation on a string the
+    // pattern no longer matches.
+    const leakedPrefix = `${'a'.repeat(24)}:${'b'.repeat(21)}`;
+    expect(out.error.message).not.toContain(leakedPrefix);
+    expect(out.error.message).toContain('[REDACTED]');
   });
 
   it('does not redact env key when env var is empty', () => {

--- a/src/utils/formatErrorResponse.js
+++ b/src/utils/formatErrorResponse.js
@@ -42,7 +42,9 @@ export function formatErrorResponse(error, toolName, extra) {
     };
   }
 
-  if (extra && Object.keys(extra).length > 0) {
+  // Guard against non-object `extra`: Object.keys(string) returns per-char
+  // indices and would silently set envelope.extra to that string.
+  if (extra && typeof extra === 'object' && Object.keys(extra).length > 0) {
     envelope.extra = extra;
   }
 

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -9,6 +9,11 @@ const __dirname = path.dirname(__filename);
 const logLevel = process.env.LOG_LEVEL || 'info';
 const isDevelopment = process.env.NODE_ENV === 'development';
 
+// Every level winston emits must route to stderr — the stdio MCP transport
+// reserves stdout for JSON-RPC frames. Single source of truth so adding a new
+// level later can't silently leave one transport routing to stdout.
+const ALL_LEVELS_TO_STDERR = ['error', 'warn', 'info', 'debug'];
+
 // Define custom log format
 const logFormat = winston.format.combine(
   winston.format.timestamp({
@@ -47,17 +52,13 @@ const logger = winston.createLogger({
     // (which uses stdout for JSON-RPC frames) is not corrupted by log lines.
     new winston.transports.Console({
       level: isDevelopment ? 'debug' : 'info',
-      stderrLevels: ['error', 'warn', 'info', 'debug'],
+      stderrLevels: ALL_LEVELS_TO_STDERR,
     }),
   ],
   // Handle uncaught exceptions
-  exceptionHandlers: [
-    new winston.transports.Console({ stderrLevels: ['error', 'warn', 'info', 'debug'] }),
-  ],
+  exceptionHandlers: [new winston.transports.Console({ stderrLevels: ALL_LEVELS_TO_STDERR })],
   // Handle unhandled promise rejections
-  rejectionHandlers: [
-    new winston.transports.Console({ stderrLevels: ['error', 'warn', 'info', 'debug'] }),
-  ],
+  rejectionHandlers: [new winston.transports.Console({ stderrLevels: ALL_LEVELS_TO_STDERR })],
 });
 
 // Add file logging in production


### PR DESCRIPTION
## Summary

Addresses four of the five findings left by the Claude bot review on #166 (the fifth is deliberately skipped; justification below).

Targets `fix/surface-ghost-api-errors` so these land as incremental commits on #166 rather than a separate merge to `main`.

### Findings addressed

1. **`extra` type guard** — restored `typeof extra === 'object' && Object.keys(extra).length > 0` in `src/utils/formatErrorResponse.js`. `Object.keys('hello')` returns per-char indices (length 5), so without the guard a future non-object caller would silently set `envelope.extra` to a string.
2. **`stderrLevels` DRY** — extracted `ALL_LEVELS_TO_STDERR` as a module-level constant in `src/utils/logger.js`; the main Console transport, exception handler, and rejection handler now reference the same array.
3. **Logger test precondition** — `src/utils/__tests__/logger.test.js` now asserts `console._stdout` and `console._stderr` exist before spying on them. They are Node internals; without the guard the test would silently turn into a no-op if Node or winston changes these references.
4. **Redact-before-truncate test** — rewrote the test in `src/utils/__tests__/sanitizeErrorPayload.test.js` to use a boundary-spanning secret (byte 4050–4139 against a 4096 cap). The previous version placed the secret past the cap, so truncation removed it regardless of redaction order — the test passed even if redaction were skipped. Verified locally by inverting the call order in `sanitizeErrorPayload.js` to `redactString(truncate(...))`: the new test fails, the old one did not.

### Finding skipped

5. `originalMessage` becoming `''` when `originalError` is undefined — `ExternalServiceError`'s constructor always populates `originalError`, so the branch is unreachable in practice. Not worth the `|| undefined` ceremony.

## Test plan

- [x] `npm test` — 1395 tests pass
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] Manually inverted `truncate(redactString(...))` → `redactString(truncate(...))` in `sanitizeErrorPayload.js` and confirmed the new boundary-spanning test fails with a 46-byte leaked prefix; reverted.

https://claude.ai/code/session_017EaCiRbzzXW47eRCid4Hxb