### PR TITLE
Improve logging, error handling, and remove unused UUID helper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,8 @@ Follow these principles when writing code:
    - `logger.js`: Context-aware logging with request correlation
    - `nqlSanitizer.js`: NQL query sanitization (consolidated from memberService and tierService)
    - `imageInputResolver.js`: Resolves image input from URL, local file path (with containment check against `GHOST_MCP_IMAGE_ROOT`), or base64 data
+   - `formatErrorResponse.js`: Builds a consistent `{error, ghost?}` envelope for all MCP tool error responses. **MUST be used for every new MCP error path** — it is the only route through `sanitizeErrorPayload` and therefore the only way error text is guaranteed to be redacted before reaching MCP clients.
+   - `sanitizeErrorPayload.js`: Secret-redaction chokepoint; deep-walks an error envelope and redacts `GHOST_ADMIN_API_KEY`, Ghost-shaped admin key patterns, URL key/token query params, and `Authorization` headers before the payload reaches MCP clients. Called internally by `formatErrorResponse` — do not call directly.
 
 ### Environment Configuration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,8 +222,8 @@ Follow these principles when writing code:
    - `logger.js`: Context-aware logging with request correlation
    - `nqlSanitizer.js`: NQL query sanitization (consolidated from memberService and tierService)
    - `imageInputResolver.js`: Resolves image input from URL, local file path (with containment check against `GHOST_MCP_IMAGE_ROOT`), or base64 data
-   - `formatErrorResponse.js`: Builds a consistent `{error, ghost?}` envelope for all MCP tool error responses. **MUST be used for every new MCP error path** — it is the only route through `sanitizeErrorPayload` and therefore the only way error text is guaranteed to be redacted before reaching MCP clients.
-   - `sanitizeErrorPayload.js`: Secret-redaction chokepoint; deep-walks an error envelope and redacts `GHOST_ADMIN_API_KEY`, Ghost-shaped admin key patterns, URL key/token query params, and `Authorization` headers before the payload reaches MCP clients. Called internally by `formatErrorResponse` — do not call directly.
+   - `formatErrorResponse.js`: Builds a consistent `{error, ghost?, extra?}` envelope for all MCP tool error responses. The optional `extra` arg is an arbitrary caller-supplied context object; if non-empty it is merged under a top-level `extra` key and sanitized alongside the rest. **MUST be used for every new MCP error path** — it is the only route through `sanitizeErrorPayload` and therefore the only way error text is guaranteed to be redacted before reaching MCP clients.
+   - `sanitizeErrorPayload.js`: Secret-redaction chokepoint; deep-walks an error envelope and redacts `GHOST_ADMIN_API_KEY`, Ghost-shaped admin key patterns, URL key/token query params, `Authorization`, `Set-Cookie`, and `Cookie` header values before the payload reaches MCP clients. Called internally by `formatErrorResponse` — do not call directly.
 
 ### Environment Configuration
 
@@ -391,6 +391,7 @@ When implementing Ghost CMS operations via MCP:
 - `express-rate-limit`: Rate limiting middleware
 
 <!-- rtk-instructions v2 -->
+
 # RTK (Rust Token Killer) - Token-Optimized Commands
 
 ## Golden Rule
@@ -398,6 +399,7 @@ When implementing Ghost CMS operations via MCP:
 **Always prefix commands with `rtk`**. If RTK has a dedicated filter, it uses it. If not, it passes through unchanged. This means RTK is always safe to use.
 
 **Important**: Even in command chains with `&&`, use `rtk`:
+
 ```bash
 # ❌ Wrong
 git add . && git commit -m "msg" && git push
@@ -409,6 +411,7 @@ rtk git add . && rtk git commit -m "msg" && rtk git push
 ## RTK Commands by Workflow
 
 ### Build & Compile (80-90% savings)
+
 ```bash
 rtk cargo build         # Cargo build output
 rtk cargo check         # Cargo check output
@@ -420,6 +423,7 @@ rtk next build          # Next.js build with route metrics (87%)
 ```
 
 ### Test (90-99% savings)
+
 ```bash
 rtk cargo test          # Cargo test failures only (90%)
 rtk vitest run          # Vitest failures only (99.5%)
@@ -428,6 +432,7 @@ rtk test <cmd>          # Generic test wrapper - failures only
 ```
 
 ### Git (59-80% savings)
+
 ```bash
 rtk git status          # Compact status
 rtk git log             # Compact log (works with all git flags)
@@ -446,6 +451,7 @@ rtk git worktree        # Compact worktree
 Note: Git passthrough works for ALL subcommands, even those not explicitly listed.
 
 ### GitHub (26-87% savings)
+
 ```bash
 rtk gh pr view <num>    # Compact PR view (87%)
 rtk gh pr checks        # Compact PR checks (79%)
@@ -455,6 +461,7 @@ rtk gh api              # Compact API responses (26%)
 ```
 
 ### JavaScript/TypeScript Tooling (70-90% savings)
+
 ```bash
 rtk pnpm list           # Compact dependency tree (70%)
 rtk pnpm outdated       # Compact outdated packages (80%)
@@ -465,6 +472,7 @@ rtk prisma              # Prisma without ASCII art (88%)
 ```
 
 ### Files & Search (60-75% savings)
+
 ```bash
 rtk ls <path>           # Tree format, compact (65%)
 rtk read <file>         # Code reading with filtering (60%)
@@ -473,6 +481,7 @@ rtk find <pattern>      # Find grouped by directory (70%)
 ```
 
 ### Analysis & Debug (70-90% savings)
+
 ```bash
 rtk err <cmd>           # Filter errors only from any command
 rtk log <file>          # Deduplicated logs with counts
@@ -484,6 +493,7 @@ rtk diff                # Ultra-compact diffs
 ```
 
 ### Infrastructure (85% savings)
+
 ```bash
 rtk docker ps           # Compact container list
 rtk docker images       # Compact image list
@@ -493,12 +503,14 @@ rtk kubectl logs        # Deduplicated pod logs
 ```
 
 ### Network (65-70% savings)
+
 ```bash
 rtk curl <url>          # Compact HTTP responses (70%)
 rtk wget <url>          # Compact download output (65%)
 ```
 
 ### Meta Commands
+
 ```bash
 rtk gain                # View token savings statistics
 rtk gain --history      # View command history with savings
@@ -510,16 +522,17 @@ rtk init --global       # Add RTK to ~/.claude/CLAUDE.md
 
 ## Token Savings Overview
 
-| Category | Commands | Typical Savings |
-|----------|----------|-----------------|
-| Tests | vitest, playwright, cargo test | 90-99% |
-| Build | next, tsc, lint, prettier | 70-87% |
-| Git | status, log, diff, add, commit | 59-80% |
-| GitHub | gh pr, gh run, gh issue | 26-87% |
-| Package Managers | pnpm, npm, npx | 70-90% |
-| Files | ls, read, grep, find | 60-75% |
-| Infrastructure | docker, kubectl | 85% |
-| Network | curl, wget | 65-70% |
+| Category         | Commands                       | Typical Savings |
+| ---------------- | ------------------------------ | --------------- |
+| Tests            | vitest, playwright, cargo test | 90-99%          |
+| Build            | next, tsc, lint, prettier      | 70-87%          |
+| Git              | status, log, diff, add, commit | 59-80%          |
+| GitHub           | gh pr, gh run, gh issue        | 26-87%          |
+| Package Managers | pnpm, npm, npx                 | 70-90%          |
+| Files            | ls, read, grep, find           | 60-75%          |
+| Infrastructure   | docker, kubectl                | 85%             |
+| Network          | curl, wget                     | 65-70%          |
 
 Overall average: **60-90% token reduction** on common development operations.
+
 <!-- /rtk-instructions -->

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -321,7 +321,7 @@ const data = validation.data;
 
 ### 3. MCP Error Response Format
 
-All MCP tool catch blocks must call `formatErrorResponse(error, toolName)` from `src/utils/formatErrorResponse.js`. This is the **only** path through the `sanitizeErrorPayload` redaction layer, so bypassing it means secrets can leak to MCP clients.
+All MCP tool catch blocks must call `formatErrorResponse(error, toolName, extra?)` from `src/utils/formatErrorResponse.js`. This is the **only** path through the `sanitizeErrorPayload` redaction layer, so bypassing it means secrets can leak to MCP clients. The optional third arg `extra` is an arbitrary caller-supplied context object (e.g. orphaned-resource details); if provided and non-empty, it is merged into the envelope under a top-level `extra` key and sanitized alongside `error`/`ghost`. A `ZodError` thrown from inside a handler is auto-coerced to a `ValidationError` so the envelope carries the correct `VALIDATION_ERROR` / `400` shape.
 
 **Envelope shape**
 

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -362,7 +362,8 @@ Before the envelope reaches any MCP client, `sanitizeErrorPayload` deep-walks ev
 - The value of `GHOST_ADMIN_API_KEY` (if present in the process environment)
 - Ghost-shaped admin key patterns (`<id>:<secret>` hex strings)
 - `key` and `token` query parameters in URLs
-- `Authorization` header values
+- `Authorization` and `Set-Cookie` header values
+- Bare `Cookie` header values (all `name=value` pairs, which may be session tokens)
 
 `sanitizeErrorPayload` is called internally by `formatErrorResponse`. Do not call it directly or construct your own error envelope — always use `formatErrorResponse`.
 
@@ -378,7 +379,7 @@ try {
 }
 ```
 
-### 5. XSS Prevention
+### 4. XSS Prevention
 
 HTML sanitization is integrated into the Zod schema layer for defense-in-depth:
 
@@ -392,7 +393,7 @@ const sanitizedHtml = htmlContentSchema.parse(userProvidedHtml);
 
 The `htmlContentSchema` uses `sanitize-html` with a strict allowlist of safe tags and attributes. See [Schema Validation](./SCHEMA_VALIDATION.md) for details.
 
-### 6. Rate Limiting
+### 5. Rate Limiting
 
 Prevents abuse and DOS attacks:
 
@@ -502,9 +503,11 @@ router.get(
 ### Unit Tests
 
 ```javascript
+import { describe, it, expect, vi } from 'vitest';
+
 describe('Error Handling', () => {
   it('should retry on transient failures', async () => {
-    const operation = jest
+    const operation = vi
       .fn()
       .mockRejectedValueOnce(new Error('Network error'))
       .mockResolvedValueOnce({ success: true });

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -172,17 +172,22 @@ router.post(
 ### MCP Tool with Error Handling
 
 ```javascript
-const tool = new Tool({
-  name: 'create_post',
-  implementation: async (input) => {
+import { formatErrorResponse } from './utils/formatErrorResponse.js';
+
+server.registerTool(
+  'ghost_create_post',
+  { description: '...', inputSchema: createPostSchema },
+  async (input) => {
     try {
       return await createPost(input);
     } catch (error) {
-      return ErrorHandler.formatMCPError(error, 'create_post');
+      return formatErrorResponse(error, 'ghost_create_post');
     }
-  },
-});
+  }
+);
 ```
+
+See the "MCP Error Response Format" section below for the envelope shape and redaction guarantees.
 
 ## Configuration
 
@@ -307,15 +312,20 @@ const data = validation.data;
 
 **Zod Error Response Format:**
 
+Zod validation errors are surfaced via `formatErrorResponse`, which emits a human-readable summary line followed by a fenced JSON block with the canonical envelope. See "MCP Error Response Format" below for the full shape. For a Zod failure, the JSON block looks like:
+
 ```json
 {
-  "content": [
-    {
-      "type": "text",
-      "text": "{\"error\":\"ValidationError\",\"message\":\"Invalid input for ghost_create_post\",\"details\":[{\"field\":\"title\",\"message\":\"Title cannot be empty\"},{\"field\":\"html\",\"message\":\"HTML content cannot be empty\"}]}"
-    }
-  ],
-  "isError": true
+  "error": {
+    "name": "ValidationError",
+    "code": "VALIDATION_ERROR",
+    "message": "ghost_create_post: Validation failed",
+    "statusCode": 400,
+    "errors": [
+      { "field": "title", "message": "Title cannot be empty", "type": "too_small" },
+      { "field": "html", "message": "HTML content cannot be empty", "type": "too_small" }
+    ]
+  }
 }
 ```
 

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -319,7 +319,56 @@ const data = validation.data;
 }
 ```
 
-### 3. XSS Prevention
+### 3. MCP Error Response Format
+
+All MCP tool catch blocks must call `formatErrorResponse(error, toolName)` from `src/utils/formatErrorResponse.js`. This is the **only** path through the `sanitizeErrorPayload` redaction layer, so bypassing it means secrets can leak to MCP clients.
+
+**Envelope shape**
+
+```json
+{
+  "error": {
+    "name": "GhostAPIError",
+    "code": "GHOST_API_ERROR",
+    "message": "Ghost API request failed",
+    "statusCode": 422
+  },
+  "ghost": {
+    "operation": "ghost_create_post",
+    "statusCode": 422,
+    "originalMessage": "Validation failed for field 'title' ..."
+  }
+}
+```
+
+- `error` is always present and contains the normalised error properties (`name`, `code`, `message`, `statusCode`).
+- `ghost` is only present when the thrown error is a `GhostAPIError`; it surfaces Ghost Admin API detail that would otherwise be swallowed.
+- `ghost.originalMessage` is the raw message from the Ghost API response, truncated at **2048 bytes** to prevent oversized payloads.
+
+**Secret redaction**
+
+Before the envelope reaches any MCP client, `sanitizeErrorPayload` deep-walks every string value and redacts:
+
+- The value of `GHOST_ADMIN_API_KEY` (if present in the process environment)
+- Ghost-shaped admin key patterns (`<id>:<secret>` hex strings)
+- `key` and `token` query parameters in URLs
+- `Authorization` header values
+
+`sanitizeErrorPayload` is called internally by `formatErrorResponse`. Do not call it directly or construct your own error envelope — always use `formatErrorResponse`.
+
+**Usage in MCP tool handlers**
+
+```javascript
+import { formatErrorResponse } from './utils/formatErrorResponse.js';
+
+try {
+  return await performOperation(input);
+} catch (error) {
+  return formatErrorResponse(error, 'ghost_create_post');
+}
+```
+
+### 5. XSS Prevention
 
 HTML sanitization is integrated into the Zod schema layer for defense-in-depth:
 
@@ -333,7 +382,7 @@ const sanitizedHtml = htmlContentSchema.parse(userProvidedHtml);
 
 The `htmlContentSchema` uses `sanitize-html` with a strict allowlist of safe tags and attributes. See [Schema Validation](./SCHEMA_VALIDATION.md) for details.
 
-### 4. Rate Limiting
+### 6. Rate Limiting
 
 Prevents abuse and DOS attacks:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2122,11 +2122,12 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }

--- a/src/mcp_server.js
+++ b/src/mcp_server.js
@@ -119,7 +119,6 @@ const escapeNqlValue = (value) => {
  */
 const withErrorHandling = (toolName, schema, handler) => {
   return async (rawInput) => {
-    console.error(`Executing tool: ${toolName}`);
     const validation = validateToolInput(schema, rawInput, toolName);
     if (!validation.success) {
       return validation.errorResponse;
@@ -188,7 +187,7 @@ server.registerTool(
     }
 
     const tags = await ghostService.getTags(options);
-    console.error(`Retrieved ${tags.length} tags from Ghost.`);
+    mcpLogger.info(`Retrieved ${tags.length} tags from Ghost.`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(tags, null, 2) }],
@@ -205,7 +204,7 @@ server.registerTool(
   },
   withErrorHandling('ghost_create_tag', createTagSchema, async (input) => {
     const createdTag = await ghostService.createTag(input);
-    console.error(`Tag created successfully. Tag ID: ${createdTag.id}`);
+    mcpLogger.info(`Tag created successfully. Tag ID: ${createdTag.id}`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(createdTag, null, 2) }],
@@ -230,7 +229,7 @@ server.registerTool(
     const identifier = input.id || `slug/${input.slug}`;
 
     const tag = await ghostService.getTag(identifier, options);
-    console.error(`Retrieved tag: ${tag.name} (ID: ${tag.id})`);
+    mcpLogger.info(`Retrieved tag: ${tag.name} (ID: ${tag.id})`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(tag, null, 2) }],
@@ -248,7 +247,7 @@ server.registerTool(
   withErrorHandling('ghost_update_tag', updateTagInputSchema, async (input) => {
     const { id, ...updateData } = input;
     const updatedTag = await ghostService.updateTag(id, updateData);
-    console.error(`Tag updated successfully. Tag ID: ${updatedTag.id}`);
+    mcpLogger.info(`Tag updated successfully. Tag ID: ${updatedTag.id}`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(updatedTag, null, 2) }],
@@ -267,7 +266,7 @@ server.registerTool(
   withErrorHandling('ghost_delete_tag', deleteTagSchema, async (input) => {
     const { id } = input;
     await ghostService.deleteTag(id);
-    console.error(`Tag deleted successfully. Tag ID: ${id}`);
+    mcpLogger.info(`Tag deleted successfully. Tag ID: ${id}`);
 
     return {
       content: [{ type: 'text', text: `Tag ${id} has been successfully deleted.` }],
@@ -436,7 +435,7 @@ function validateAndXorImageInput(schema, rawInput, toolName) {
   if (xorError) {
     return {
       success: false,
-      errorResponse: { content: [{ type: 'text', text: xorError }], isError: true },
+      errorResponse: formatErrorResponse(new Error(xorError), toolName),
     };
   }
   return validation;
@@ -522,7 +521,7 @@ server.registerTool(
         type === 'post'
           ? await ghostService.updatePost(id, updatePayload)
           : await ghostService.updatePage(id, updatePayload);
-      console.error(`ghost_set_feature_image: ${type} ${id} updated with ${uploadedUrl}`);
+      mcpLogger.info(`ghost_set_feature_image: ${type} ${id} updated with ${uploadedUrl}`);
       return {
         content: [
           {
@@ -592,7 +591,7 @@ server.registerTool(
   },
   withErrorHandling('ghost_create_post', createPostSchema, async (input) => {
     const createdPost = await postService.createPostService(input);
-    console.error(`Post created successfully. Post ID: ${createdPost.id}`);
+    mcpLogger.info(`Post created successfully. Post ID: ${createdPost.id}`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(createdPost, null, 2) }],
@@ -621,7 +620,7 @@ server.registerTool(
     if (input.formats !== undefined) options.formats = input.formats;
 
     const posts = await ghostService.getPosts(options);
-    console.error(`Retrieved ${posts.length} posts from Ghost.`);
+    mcpLogger.info(`Retrieved ${posts.length} posts from Ghost.`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(posts, null, 2) }],
@@ -648,7 +647,7 @@ server.registerTool(
     const identifier = input.id || `slug/${input.slug}`;
 
     const post = await ghostService.getPost(identifier, options);
-    console.error(`Retrieved post: ${post.title} (ID: ${post.id})`);
+    mcpLogger.info(`Retrieved post: ${post.title} (ID: ${post.id})`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(post, null, 2) }],
@@ -670,7 +669,7 @@ server.registerTool(
     if (input.limit !== undefined) options.limit = input.limit;
 
     const posts = await ghostService.searchPosts(input.query, options);
-    console.error(`Found ${posts.length} posts matching "${input.query}".`);
+    mcpLogger.info(`Found ${posts.length} posts matching "${input.query}".`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(posts, null, 2) }],
@@ -691,7 +690,7 @@ server.registerTool(
     const { id, ...updateData } = input;
 
     const updatedPost = await ghostService.updatePost(id, updateData);
-    console.error(`Post updated successfully. Post ID: ${updatedPost.id}`);
+    mcpLogger.info(`Post updated successfully. Post ID: ${updatedPost.id}`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(updatedPost, null, 2) }],
@@ -710,7 +709,7 @@ server.registerTool(
   withErrorHandling('ghost_delete_post', deletePostSchema, async (input) => {
     const { id } = input;
     await ghostService.deletePost(id);
-    console.error(`Post deleted successfully. Post ID: ${id}`);
+    mcpLogger.info(`Post deleted successfully. Post ID: ${id}`);
 
     return {
       content: [{ type: 'text', text: `Post ${id} has been successfully deleted.` }],
@@ -780,7 +779,7 @@ server.registerTool(
     if (input.order !== undefined) options.order = input.order;
 
     const pages = await ghostService.getPages(options);
-    console.error(`Retrieved ${pages.length} pages from Ghost.`);
+    mcpLogger.info(`Retrieved ${pages.length} pages from Ghost.`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(pages, null, 2) }],
@@ -805,7 +804,7 @@ server.registerTool(
     const identifier = input.id || `slug/${input.slug}`;
 
     const page = await ghostService.getPage(identifier, options);
-    console.error(`Retrieved page: ${page.title} (ID: ${page.id})`);
+    mcpLogger.info(`Retrieved page: ${page.title} (ID: ${page.id})`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(page, null, 2) }],
@@ -823,7 +822,7 @@ server.registerTool(
   },
   withErrorHandling('ghost_create_page', createPageSchema, async (input) => {
     const createdPage = await pageService.createPageService(input);
-    console.error(`Page created successfully. Page ID: ${createdPage.id}`);
+    mcpLogger.info(`Page created successfully. Page ID: ${createdPage.id}`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(createdPage, null, 2) }],
@@ -843,7 +842,7 @@ server.registerTool(
     const { id, ...updateData } = input;
 
     const updatedPage = await ghostService.updatePage(id, updateData);
-    console.error(`Page updated successfully. Page ID: ${updatedPage.id}`);
+    mcpLogger.info(`Page updated successfully. Page ID: ${updatedPage.id}`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(updatedPage, null, 2) }],
@@ -862,7 +861,7 @@ server.registerTool(
   withErrorHandling('ghost_delete_page', deletePageSchema, async (input) => {
     const { id } = input;
     await ghostService.deletePage(id);
-    console.error(`Page deleted successfully. Page ID: ${id}`);
+    mcpLogger.info(`Page deleted successfully. Page ID: ${id}`);
 
     return {
       content: [{ type: 'text', text: `Page ${id} has been successfully deleted.` }],
@@ -883,7 +882,7 @@ server.registerTool(
     if (input.limit !== undefined) options.limit = input.limit;
 
     const pages = await ghostService.searchPages(input.query, options);
-    console.error(`Found ${pages.length} pages matching "${input.query}".`);
+    mcpLogger.info(`Found ${pages.length} pages matching "${input.query}".`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(pages, null, 2) }],
@@ -931,7 +930,7 @@ server.registerTool(
   },
   withErrorHandling('ghost_create_member', createMemberSchema, async (input) => {
     const createdMember = await ghostService.createMember(input);
-    console.error(`Member created successfully. Member ID: ${createdMember.id}`);
+    mcpLogger.info(`Member created successfully. Member ID: ${createdMember.id}`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(createdMember, null, 2) }],
@@ -950,7 +949,7 @@ server.registerTool(
     const { id, ...updateData } = input;
 
     const updatedMember = await ghostService.updateMember(id, updateData);
-    console.error(`Member updated successfully. Member ID: ${updatedMember.id}`);
+    mcpLogger.info(`Member updated successfully. Member ID: ${updatedMember.id}`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(updatedMember, null, 2) }],
@@ -969,7 +968,7 @@ server.registerTool(
   withErrorHandling('ghost_delete_member', deleteMemberSchema, async (input) => {
     const { id } = input;
     await ghostService.deleteMember(id);
-    console.error(`Member deleted successfully. Member ID: ${id}`);
+    mcpLogger.info(`Member deleted successfully. Member ID: ${id}`);
 
     return {
       content: [{ type: 'text', text: `Member ${id} has been successfully deleted.` }],
@@ -994,7 +993,7 @@ server.registerTool(
     if (input.include !== undefined) options.include = input.include;
 
     const members = await ghostService.getMembers(options);
-    console.error(`Retrieved ${members.length} members from Ghost.`);
+    mcpLogger.info(`Retrieved ${members.length} members from Ghost.`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(members, null, 2) }],
@@ -1013,7 +1012,7 @@ server.registerTool(
   withErrorHandling('ghost_get_member', getMemberSchema, async (input) => {
     const { id, email } = input;
     const member = await ghostService.getMember({ id, email });
-    console.error(`Retrieved member: ${member.email} (ID: ${member.id})`);
+    mcpLogger.info(`Retrieved member: ${member.email} (ID: ${member.id})`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(member, null, 2) }],
@@ -1034,7 +1033,7 @@ server.registerTool(
     if (limit !== undefined) options.limit = limit;
 
     const members = await ghostService.searchMembers(query, options);
-    console.error(`Found ${members.length} members matching "${query}".`);
+    mcpLogger.info(`Found ${members.length} members matching "${query}".`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(members, null, 2) }],
@@ -1066,7 +1065,7 @@ server.registerTool(
     if (input.order !== undefined) options.order = input.order;
 
     const newsletters = await ghostService.getNewsletters(options);
-    console.error(`Retrieved ${newsletters.length} newsletters from Ghost.`);
+    mcpLogger.info(`Retrieved ${newsletters.length} newsletters from Ghost.`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(newsletters, null, 2) }],
@@ -1084,7 +1083,7 @@ server.registerTool(
   withErrorHandling('ghost_get_newsletter', getNewsletterSchema, async (input) => {
     const { id } = input;
     const newsletter = await ghostService.getNewsletter(id);
-    console.error(`Retrieved newsletter: ${newsletter.name} (ID: ${newsletter.id})`);
+    mcpLogger.info(`Retrieved newsletter: ${newsletter.name} (ID: ${newsletter.id})`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(newsletter, null, 2) }],
@@ -1102,7 +1101,7 @@ server.registerTool(
   },
   withErrorHandling('ghost_create_newsletter', createNewsletterSchema, async (input) => {
     const createdNewsletter = await newsletterService.createNewsletterService(input);
-    console.error(`Newsletter created successfully. Newsletter ID: ${createdNewsletter.id}`);
+    mcpLogger.info(`Newsletter created successfully. Newsletter ID: ${createdNewsletter.id}`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(createdNewsletter, null, 2) }],
@@ -1122,7 +1121,7 @@ server.registerTool(
     const { id, ...updateData } = input;
 
     const updatedNewsletter = await ghostService.updateNewsletter(id, updateData);
-    console.error(`Newsletter updated successfully. Newsletter ID: ${updatedNewsletter.id}`);
+    mcpLogger.info(`Newsletter updated successfully. Newsletter ID: ${updatedNewsletter.id}`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(updatedNewsletter, null, 2) }],
@@ -1141,7 +1140,7 @@ server.registerTool(
   withErrorHandling('ghost_delete_newsletter', deleteNewsletterSchema, async (input) => {
     const { id } = input;
     await ghostService.deleteNewsletter(id);
-    console.error(`Newsletter deleted successfully. Newsletter ID: ${id}`);
+    mcpLogger.info(`Newsletter deleted successfully. Newsletter ID: ${id}`);
 
     return {
       content: [{ type: 'text', text: `Newsletter ${id} has been successfully deleted.` }],
@@ -1166,7 +1165,7 @@ server.registerTool(
   },
   withErrorHandling('ghost_get_tiers', tierQuerySchema, async (input) => {
     const tiers = await ghostService.getTiers(input);
-    console.error(`Retrieved ${tiers.length} tiers`);
+    mcpLogger.info(`Retrieved ${tiers.length} tiers`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(tiers, null, 2) }],
@@ -1184,7 +1183,7 @@ server.registerTool(
   withErrorHandling('ghost_get_tier', getTierSchema, async (input) => {
     const { id } = input;
     const tier = await ghostService.getTier(id);
-    console.error(`Tier retrieved successfully. Tier ID: ${tier.id}`);
+    mcpLogger.info(`Tier retrieved successfully. Tier ID: ${tier.id}`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(tier, null, 2) }],
@@ -1201,7 +1200,7 @@ server.registerTool(
   },
   withErrorHandling('ghost_create_tier', createTierSchema, async (input) => {
     const tier = await ghostService.createTier(input);
-    console.error(`Tier created successfully. Tier ID: ${tier.id}`);
+    mcpLogger.info(`Tier created successfully. Tier ID: ${tier.id}`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(tier, null, 2) }],
@@ -1221,7 +1220,7 @@ server.registerTool(
     const { id, ...updateData } = input;
 
     const updatedTier = await ghostService.updateTier(id, updateData);
-    console.error(`Tier updated successfully. Tier ID: ${updatedTier.id}`);
+    mcpLogger.info(`Tier updated successfully. Tier ID: ${updatedTier.id}`);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(updatedTier, null, 2) }],
@@ -1240,7 +1239,7 @@ server.registerTool(
   withErrorHandling('ghost_delete_tier', deleteTierSchema, async (input) => {
     const { id } = input;
     await ghostService.deleteTier(id);
-    console.error(`Tier deleted successfully. Tier ID: ${id}`);
+    mcpLogger.info(`Tier deleted successfully. Tier ID: ${id}`);
 
     return {
       content: [{ type: 'text', text: `Tier ${id} has been successfully deleted.` }],
@@ -1258,7 +1257,7 @@ async function main() {
 
   console.error('Ghost MCP Server running on stdio transport');
   console.error(
-    'Available tools: ghost_get_tags, ghost_create_tag, ghost_get_tag, ghost_update_tag, ghost_delete_tag, ghost_upload_image, ' +
+    'Available tools: ghost_get_tags, ghost_create_tag, ghost_get_tag, ghost_update_tag, ghost_delete_tag, ghost_upload_image, ghost_set_feature_image, ' +
       'ghost_create_post, ghost_get_posts, ghost_get_post, ghost_search_posts, ghost_update_post, ghost_delete_post, ' +
       'ghost_get_pages, ghost_get_page, ghost_create_page, ghost_update_page, ghost_delete_page, ghost_search_pages, ' +
       'ghost_create_member, ghost_update_member, ghost_delete_member, ghost_get_members, ghost_get_member, ghost_search_members, ' +

--- a/src/mcp_server.js
+++ b/src/mcp_server.js
@@ -76,9 +76,6 @@ const loadServices = async () => {
   }
 };
 
-// Generate UUID without external dependency
-const generateUuid = () => crypto.randomUUID();
-
 // Helper function for default alt text
 const getDefaultAltText = (filePath) => {
   try {
@@ -223,9 +220,6 @@ server.registerTool(
     const options = {};
     if (input.include !== undefined) options.include = input.include;
 
-    if (!input.id && !input.slug) {
-      throw new Error('Either id or slug is required');
-    }
     const identifier = input.id || `slug/${input.slug}`;
 
     const tag = await ghostService.getTag(identifier, options);
@@ -345,8 +339,8 @@ async function acquireImageForUpload({ imageUrl, imagePath: localPath, imageBase
 
     const extension = path.extname(imageUrl.split('?')[0]) || '.tmp';
     const filenameHint =
-      path.basename(imageUrl.split('?')[0]) || `image-${generateUuid()}${extension}`;
-    const downloadedPath = path.join(tempDir, `mcp-download-${generateUuid()}${extension}`);
+      path.basename(imageUrl.split('?')[0]) || `image-${crypto.randomUUID()}${extension}`;
+    const downloadedPath = path.join(tempDir, `mcp-download-${crypto.randomUUID()}${extension}`);
 
     let bytes = 0;
     response.data.on('data', (chunk) => {
@@ -640,10 +634,7 @@ server.registerTool(
     const options = {};
     if (input.include !== undefined) options.include = input.include;
 
-    // Determine identifier (prefer ID over slug)
-    if (!input.id && !input.slug) {
-      throw new Error('Either id or slug is required');
-    }
+    // Prefer ID over slug. The schema's .refine() guarantees one is present.
     const identifier = input.id || `slug/${input.slug}`;
 
     const post = await ghostService.getPost(identifier, options);
@@ -798,9 +789,6 @@ server.registerTool(
     const options = {};
     if (input.include !== undefined) options.include = input.include;
 
-    if (!input.id && !input.slug) {
-      throw new Error('Either id or slug is required');
-    }
     const identifier = input.id || `slug/${input.slug}`;
 
     const page = await ghostService.getPage(identifier, options);

--- a/src/mcp_server.js
+++ b/src/mcp_server.js
@@ -11,24 +11,6 @@ import crypto from 'crypto';
 import { validateToolInput } from './utils/validation.js';
 import { formatErrorResponse } from './utils/formatErrorResponse.js';
 import { createContextLogger } from './utils/logger.js';
-
-const mcpLogger = createContextLogger('mcp-server');
-
-/**
- * Emit structured log fields for a caught error. Never passes the raw error
- * object to the logger — Ghost SDK errors carry request headers/URLs that
- * include credentials.
- */
-const logToolError = (toolName, error, extra = {}) => {
-  mcpLogger.error(`Tool ${toolName} failed`, {
-    tool: toolName,
-    errorName: error?.name,
-    errorMessage: error?.message,
-    errorCode: error?.code,
-    ghostStatusCode: error?.ghostStatusCode,
-    ...extra,
-  });
-};
 import { trackTempFile, cleanupTempFiles } from './utils/tempFileManager.js';
 import { resolveLocalImagePath, decodeBase64ToTempFile } from './utils/imageInputResolver.js';
 import {
@@ -56,6 +38,24 @@ import {
 
 // Load environment variables
 dotenv.config({ quiet: true });
+
+const mcpLogger = createContextLogger('mcp-server');
+
+/**
+ * Emit structured log fields for a caught error. Never passes the raw error
+ * object to the logger — Ghost SDK errors carry request headers/URLs that
+ * include credentials.
+ */
+const logToolError = (toolName, error, extra = {}) => {
+  mcpLogger.error(`Tool ${toolName} failed`, {
+    tool: toolName,
+    errorName: error?.name,
+    errorMessage: error?.message,
+    errorCode: error?.code,
+    ghostStatusCode: error?.ghostStatusCode,
+    ...extra,
+  });
+};
 
 // Lazy-loaded modules (to avoid Node.js v25 Buffer compatibility issues at startup)
 let ghostService = null;

--- a/src/mcp_server.js
+++ b/src/mcp_server.js
@@ -10,6 +10,25 @@ import os from 'os';
 import crypto from 'crypto';
 import { validateToolInput } from './utils/validation.js';
 import { formatErrorResponse } from './utils/formatErrorResponse.js';
+import { createContextLogger } from './utils/logger.js';
+
+const mcpLogger = createContextLogger('mcp-server');
+
+/**
+ * Emit structured log fields for a caught error. Never passes the raw error
+ * object to the logger — Ghost SDK errors carry request headers/URLs that
+ * include credentials.
+ */
+const logToolError = (toolName, error, extra = {}) => {
+  mcpLogger.error(`Tool ${toolName} failed`, {
+    tool: toolName,
+    errorName: error?.name,
+    errorMessage: error?.message,
+    errorCode: error?.code,
+    ghostStatusCode: error?.ghostStatusCode,
+    ...extra,
+  });
+};
 import { trackTempFile, cleanupTempFiles } from './utils/tempFileManager.js';
 import { resolveLocalImagePath, decodeBase64ToTempFile } from './utils/imageInputResolver.js';
 import {
@@ -110,7 +129,7 @@ const withErrorHandling = (toolName, schema, handler) => {
       await loadServices();
       return await handler(validation.data);
     } catch (error) {
-      console.error(`Error in ${toolName}:`, error);
+      logToolError(toolName, error);
       return formatErrorResponse(error, toolName);
     }
   };
@@ -441,7 +460,7 @@ server.registerTool(
       if (uploadResult.ref) result.ref = uploadResult.ref;
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
     } catch (error) {
-      console.error(`Error in ghost_upload_image:`, error);
+      logToolError('ghost_upload_image', error);
       return formatErrorResponse(error, 'ghost_upload_image');
     }
   }
@@ -488,7 +507,7 @@ server.registerTool(
       uploadedRef = uploadResult.ref;
       altText = finalAltText;
     } catch (error) {
-      console.error(`ghost_set_feature_image: upload failed`, error);
+      logToolError('ghost_set_feature_image', error, { phase: 'upload' });
       return formatErrorResponse(error, 'ghost_set_feature_image');
     }
 
@@ -517,7 +536,10 @@ server.registerTool(
         ],
       };
     } catch (error) {
-      console.error(`ghost_set_feature_image: update failed (orphaned ${uploadedUrl})`, error);
+      logToolError('ghost_set_feature_image', error, {
+        phase: 'update',
+        orphanedUrl: uploadedUrl,
+      });
       return formatErrorResponse(error, 'ghost_set_feature_image', {
         orphanedImage: { url: uploadedUrl, ref: uploadedRef, alt: altText },
         hint: 'Ghost does not expose a delete-image endpoint; reuse this URL or leave it orphaned.',

--- a/src/mcp_server.js
+++ b/src/mcp_server.js
@@ -8,8 +8,8 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import crypto from 'crypto';
-import { ValidationError } from './errors/index.js';
 import { validateToolInput } from './utils/validation.js';
+import { formatErrorResponse } from './utils/formatErrorResponse.js';
 import { trackTempFile, cleanupTempFiles } from './utils/tempFileManager.js';
 import { resolveLocalImagePath, decodeBase64ToTempFile } from './utils/imageInputResolver.js';
 import {
@@ -99,7 +99,6 @@ const escapeNqlValue = (value) => {
  * @returns {Function} Wrapped async handler for server.registerTool
  */
 const withErrorHandling = (toolName, schema, handler) => {
-  const zodContext = toolName.replace('ghost_', '').replace(/_/g, ' ');
   return async (rawInput) => {
     console.error(`Executing tool: ${toolName}`);
     const validation = validateToolInput(schema, rawInput, toolName);
@@ -112,17 +111,7 @@ const withErrorHandling = (toolName, schema, handler) => {
       return await handler(validation.data);
     } catch (error) {
       console.error(`Error in ${toolName}:`, error);
-      if (error.name === 'ZodError') {
-        const validationError = ValidationError.fromZod(error, zodContext);
-        return {
-          content: [{ type: 'text', text: JSON.stringify(validationError.toJSON(), null, 2) }],
-          isError: true,
-        };
-      }
-      return {
-        content: [{ type: 'text', text: `Error in ${toolName}: ${error.message}` }],
-        isError: true,
-      };
+      return formatErrorResponse(error, toolName);
     }
   };
 };
@@ -453,10 +442,7 @@ server.registerTool(
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
     } catch (error) {
       console.error(`Error in ghost_upload_image:`, error);
-      return {
-        content: [{ type: 'text', text: `Error uploading image: ${error.message}` }],
-        isError: true,
-      };
+      return formatErrorResponse(error, 'ghost_upload_image');
     }
   }
 );
@@ -503,10 +489,7 @@ server.registerTool(
       altText = finalAltText;
     } catch (error) {
       console.error(`ghost_set_feature_image: upload failed`, error);
-      return {
-        content: [{ type: 'text', text: `Upload failed: ${error.message}` }],
-        isError: true,
-      };
+      return formatErrorResponse(error, 'ghost_set_feature_image');
     }
 
     const updatePayload = {
@@ -535,23 +518,17 @@ server.registerTool(
       };
     } catch (error) {
       console.error(`ghost_set_feature_image: update failed (orphaned ${uploadedUrl})`, error);
-      return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(
-              {
-                error: `Upload succeeded but ${type} update failed: ${error.message}`,
-                orphanedImage: { url: uploadedUrl, ref: uploadedRef, alt: altText },
-                hint: 'Ghost does not expose a delete-image endpoint; reuse this URL or leave it orphaned.',
-              },
-              null,
-              2
-            ),
-          },
-        ],
-        isError: true,
-      };
+      const response = formatErrorResponse(error, 'ghost_set_feature_image');
+      const orphanInfo = JSON.stringify(
+        {
+          orphanedImage: { url: uploadedUrl, ref: uploadedRef, alt: altText },
+          hint: 'Ghost does not expose a delete-image endpoint; reuse this URL or leave it orphaned.',
+        },
+        null,
+        2
+      );
+      response.content[0].text += `\n\n${orphanInfo}`;
+      return response;
     }
   }
 );

--- a/src/mcp_server.js
+++ b/src/mcp_server.js
@@ -518,17 +518,10 @@ server.registerTool(
       };
     } catch (error) {
       console.error(`ghost_set_feature_image: update failed (orphaned ${uploadedUrl})`, error);
-      const response = formatErrorResponse(error, 'ghost_set_feature_image');
-      const orphanInfo = JSON.stringify(
-        {
-          orphanedImage: { url: uploadedUrl, ref: uploadedRef, alt: altText },
-          hint: 'Ghost does not expose a delete-image endpoint; reuse this URL or leave it orphaned.',
-        },
-        null,
-        2
-      );
-      response.content[0].text += `\n\n${orphanInfo}`;
-      return response;
+      return formatErrorResponse(error, 'ghost_set_feature_image', {
+        orphanedImage: { url: uploadedUrl, ref: uploadedRef, alt: altText },
+        hint: 'Ghost does not expose a delete-image endpoint; reuse this URL or leave it orphaned.',
+      });
     }
   }
 );

--- a/src/utils/__tests__/formatErrorResponse.test.js
+++ b/src/utils/__tests__/formatErrorResponse.test.js
@@ -92,4 +92,67 @@ describe('formatErrorResponse', () => {
     expect(envelope.error.code).toBe('NOT_FOUND');
     expect(envelope).not.toHaveProperty('ghost');
   });
+
+  describe('extra context', () => {
+    it('includes and sanitizes extra context when provided', () => {
+      const extra = {
+        orphanedImage: { url: 'https://cdn.example/img.jpg?key=LEAK_ME_XYZ', ref: 'r1' },
+      };
+      const response = formatErrorResponse(new Error('boom'), 'ghost_set_feature_image', extra);
+      const envelope = parseJsonBlock(response.content[0].text);
+      expect(envelope.extra).toBeDefined();
+      expect(envelope.extra.orphanedImage.url).toContain('key=[REDACTED]');
+      expect(response.content[0].text).not.toContain('LEAK_ME_XYZ');
+    });
+
+    it('omits extra key entirely when arg is not provided', () => {
+      const envelope = parseJsonBlock(
+        formatErrorResponse(new Error('boom'), 'ghost_update_post').content[0].text
+      );
+      expect(envelope).not.toHaveProperty('extra');
+    });
+
+    it('omits extra key when arg is empty object (no empty-object leak)', () => {
+      const envelope = parseJsonBlock(
+        formatErrorResponse(new Error('boom'), 'ghost_update_post', {}).content[0].text
+      );
+      expect(envelope).not.toHaveProperty('extra');
+    });
+
+    it('combines error, ghost, and extra when all apply', () => {
+      const err = new GhostAPIError('posts.edit', 'bad', 422);
+      const envelope = parseJsonBlock(
+        formatErrorResponse(err, 'ghost_set_feature_image', { orphanedImage: { url: 'x' } })
+          .content[0].text
+      );
+      expect(envelope.error).toBeDefined();
+      expect(envelope.ghost).toBeDefined();
+      expect(envelope.extra).toBeDefined();
+    });
+  });
+
+  describe('ZodError coercion', () => {
+    it('coerces ZodError-shaped input to VALIDATION_ERROR / 400 envelope', () => {
+      const zodLike = Object.assign(new Error('zod'), {
+        name: 'ZodError',
+        issues: [{ path: ['purpose'], message: 'Invalid enum value', code: 'invalid_enum_value' }],
+      });
+      const envelope = parseJsonBlock(
+        formatErrorResponse(zodLike, 'ghost_upload_image').content[0].text
+      );
+      expect(envelope.error.code).toBe('VALIDATION_ERROR');
+      expect(envelope.error.statusCode).toBe(400);
+      expect(envelope.error.errors).toEqual([
+        { field: 'purpose', message: 'Invalid enum value', type: 'invalid_enum_value' },
+      ]);
+    });
+
+    it('does not coerce a non-ZodError error that happens to have an issues field', () => {
+      const notZod = Object.assign(new Error('unrelated'), { issues: [] });
+      const envelope = parseJsonBlock(
+        formatErrorResponse(notZod, 'ghost_update_post').content[0].text
+      );
+      expect(envelope.error.code).toBe('UNKNOWN');
+    });
+  });
 });

--- a/src/utils/__tests__/formatErrorResponse.test.js
+++ b/src/utils/__tests__/formatErrorResponse.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { formatErrorResponse } from '../formatErrorResponse.js';
+import { GhostAPIError, ValidationError, NotFoundError } from '../../errors/index.js';
+
+function parseJsonBlock(text) {
+  const match = text.match(/```json\n([\s\S]+?)\n```/);
+  expect(match, `no JSON block in: ${text}`).toBeTruthy();
+  return JSON.parse(match[1]);
+}
+
+describe('formatErrorResponse', () => {
+  const originalEnv = process.env.GHOST_ADMIN_API_KEY;
+
+  beforeEach(() => {
+    process.env.GHOST_ADMIN_API_KEY = '';
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.GHOST_ADMIN_API_KEY;
+    else process.env.GHOST_ADMIN_API_KEY = originalEnv;
+  });
+
+  it('returns consistent envelope with error key for generic Error (no ghost key)', () => {
+    const response = formatErrorResponse(new Error('boom'), 'ghost_get_posts');
+    expect(response.isError).toBe(true);
+    expect(response.content[0].type).toBe('text');
+    const envelope = parseJsonBlock(response.content[0].text);
+    expect(envelope.error).toBeDefined();
+    expect(envelope.error.message).toBe('boom');
+    expect(envelope).not.toHaveProperty('ghost');
+    expect(response.content[0].text).toContain('Error in ghost_get_posts: boom');
+  });
+
+  it('includes gated ghost sub-object for GhostAPIError', () => {
+    const err = new GhostAPIError('posts.edit', 'Title is required', 422);
+    const response = formatErrorResponse(err, 'ghost_update_post');
+    const envelope = parseJsonBlock(response.content[0].text);
+    expect(envelope.error.name).toBe('GhostAPIError');
+    expect(envelope.error.code).toBe('GHOST_VALIDATION_ERROR');
+    expect(envelope.ghost).toBeDefined();
+    expect(envelope.ghost.operation).toBe('posts.edit');
+    expect(envelope.ghost.statusCode).toBe(422);
+    expect(envelope.ghost.originalMessage).toBe('Title is required');
+    expect(response.content[0].text).toContain('422');
+    expect(response.content[0].text).toContain('posts.edit');
+    expect(response.content[0].text).toContain('Title is required');
+  });
+
+  it('uses raw ghostStatusCode (not remapped statusCode) in ghost envelope', () => {
+    const err = new GhostAPIError('posts.edit', 'bad', 422);
+    // GhostAPIError remaps 422 -> 400 for .statusCode; ghost.statusCode must be 422
+    expect(err.statusCode).toBe(400);
+    expect(err.ghostStatusCode).toBe(422);
+    const envelope = parseJsonBlock(formatErrorResponse(err, 'ghost_update_post').content[0].text);
+    expect(envelope.ghost.statusCode).toBe(422);
+    expect(envelope.error.statusCode).toBe(400);
+  });
+
+  it('does not leak GHOST_ADMIN_API_KEY in surfaced response', () => {
+    process.env.GHOST_ADMIN_API_KEY = 'plaintext-admin-key-xyz';
+    const err = new GhostAPIError(
+      'posts.edit',
+      'Ghost complained: token plaintext-admin-key-xyz invalid',
+      401
+    );
+    const response = formatErrorResponse(err, 'ghost_update_post');
+    expect(response.content[0].text).not.toContain('plaintext-admin-key-xyz');
+    expect(response.content[0].text).toContain('[REDACTED]');
+  });
+
+  it('does not leak Ghost-shaped admin key pattern in originalMessage', () => {
+    const fakeKey = `${'1'.repeat(24)}:${'2'.repeat(64)}`;
+    const err = new GhostAPIError('posts.edit', `failed with ${fakeKey}`, 401);
+    const response = formatErrorResponse(err, 'ghost_update_post');
+    expect(response.content[0].text).not.toContain(fakeKey);
+  });
+
+  it('produces envelope for ValidationError (no ghost key)', () => {
+    const err = new ValidationError('Validation failed', [
+      { field: 'title', message: 'required', type: 'invalid_type' },
+    ]);
+    const response = formatErrorResponse(err, 'ghost_update_post');
+    const envelope = parseJsonBlock(response.content[0].text);
+    expect(envelope.error.code).toBe('VALIDATION_ERROR');
+    expect(envelope).not.toHaveProperty('ghost');
+  });
+
+  it('produces envelope for NotFoundError (no ghost key)', () => {
+    const err = new NotFoundError('Post', 'abc');
+    const response = formatErrorResponse(err, 'ghost_get_post');
+    const envelope = parseJsonBlock(response.content[0].text);
+    expect(envelope.error.code).toBe('NOT_FOUND');
+    expect(envelope).not.toHaveProperty('ghost');
+  });
+});

--- a/src/utils/__tests__/formatErrorResponse.test.js
+++ b/src/utils/__tests__/formatErrorResponse.test.js
@@ -131,6 +131,26 @@ describe('formatErrorResponse', () => {
     });
   });
 
+  describe('XOR image-input error pass-through', () => {
+    it('renders the XOR error through the sanitized envelope shape', () => {
+      // Mirror the call shape `validateAndXorImageInput` uses when the caller
+      // supplied more than one of imageUrl/imagePath/imageBase64.
+      const xorError = new Error('Provide exactly one of imageUrl, imagePath, or imageBase64.');
+      const response = formatErrorResponse(xorError, 'ghost_upload_image');
+
+      expect(response.isError).toBe(true);
+      expect(response.content[0].type).toBe('text');
+      expect(response.content[0].text).toContain('Error in ghost_upload_image:');
+
+      const envelope = parseJsonBlock(response.content[0].text);
+      expect(envelope.error).toBeDefined();
+      expect(envelope.error.message).toBe(
+        'Provide exactly one of imageUrl, imagePath, or imageBase64.'
+      );
+      expect(envelope).not.toHaveProperty('ghost');
+    });
+  });
+
   describe('ZodError coercion', () => {
     it('coerces ZodError-shaped input to VALIDATION_ERROR / 400 envelope', () => {
       const zodLike = Object.assign(new Error('zod'), {

--- a/src/utils/__tests__/logger.test.js
+++ b/src/utils/__tests__/logger.test.js
@@ -32,6 +32,14 @@ describe('logger', () => {
       // Winston writes to console._stdout/_stderr (Node aliases for
       // process.stdout/stderr, captured at logger construction). Spy on the
       // same references winston uses so the hook lines up with the write.
+      // These are Node internals — fail loudly if they ever disappear so the
+      // test cannot silently turn into a no-op when the assumption breaks.
+      if (!console._stdout || !console._stderr) {
+        throw new Error(
+          'console._stdout/_stderr unavailable; logger transport-routing test ' +
+            'assumptions broken — winston uses these refs for its Console transport.'
+        );
+      }
       stdoutSpy = vi.spyOn(console._stdout, 'write').mockImplementation(() => true);
       stderrSpy = vi.spyOn(console._stderr, 'write').mockImplementation(() => true);
     });

--- a/src/utils/__tests__/logger.test.js
+++ b/src/utils/__tests__/logger.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { LEVEL, MESSAGE } from 'triple-beam';
 import { createContextLogger } from '../logger.js';
 import logger from '../logger.js';
 
@@ -18,6 +19,54 @@ describe('logger', () => {
       expect(logger).toHaveProperty('warn');
       expect(logger).toHaveProperty('debug');
       expect(logger).toHaveProperty('log');
+    });
+  });
+
+  describe('transport routing', () => {
+    // stdio MCP transport uses stdout for JSON-RPC frames; all log output must
+    // land on stderr so a log line cannot corrupt the protocol channel.
+    let stdoutSpy;
+    let stderrSpy;
+
+    beforeEach(() => {
+      // Winston writes to console._stdout/_stderr (Node aliases for
+      // process.stdout/stderr, captured at logger construction). Spy on the
+      // same references winston uses so the hook lines up with the write.
+      stdoutSpy = vi.spyOn(console._stdout, 'write').mockImplementation(() => true);
+      stderrSpy = vi.spyOn(console._stderr, 'write').mockImplementation(() => true);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('configures the Console transport with stderrLevels covering every level', () => {
+      const consoleTransport = logger.transports.find((t) => t.name === 'console');
+      expect(consoleTransport).toBeDefined();
+      expect(consoleTransport.stderrLevels).toMatchObject({
+        error: true,
+        warn: true,
+        info: true,
+        debug: true,
+      });
+    });
+
+    // Drive the Console transport's log() directly. Winston's writable-stream
+    // pipeline can defer writes across ticks, so routing the message through
+    // logger.info() makes the test flaky. The transport's routing logic is
+    // synchronous, so calling log() with a winston-shaped info object covers it.
+    const makeInfo = (level, message) => ({
+      level,
+      message,
+      [LEVEL]: level,
+      [MESSAGE]: `formatted: ${message}`,
+    });
+
+    it.each([['error'], ['warn'], ['info'], ['debug']])('routes %s level to stderr', (level) => {
+      const transport = logger.transports.find((t) => t.name === 'console');
+      transport.log(makeInfo(level, `${level}-test`), () => {});
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining(`${level}-test`));
+      expect(stdoutSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/utils/__tests__/sanitizeErrorPayload.test.js
+++ b/src/utils/__tests__/sanitizeErrorPayload.test.js
@@ -60,6 +60,38 @@ describe('sanitizeErrorPayload', () => {
     expect(out.error.message).toContain('[REDACTED]');
   });
 
+  it('redacts every value in a multi-value Cookie header', () => {
+    const out = sanitizeErrorPayload({
+      error: { message: 'Cookie: a=first; b=SECRET_SESSION; c=third' },
+    });
+    expect(out.error.message).not.toContain('SECRET_SESSION');
+    expect(out.error.message).not.toContain('a=first');
+    expect(out.error.message).not.toContain('c=third');
+    expect(out.error.message).toContain('Cookie: [REDACTED]');
+  });
+
+  it('redacts Set-Cookie value but preserves attributes (HttpOnly, Secure, Path)', () => {
+    const out = sanitizeErrorPayload({
+      error: { message: 'Set-Cookie: sess=TOKEN_XYZ; HttpOnly; Secure; Path=/' },
+    });
+    expect(out.error.message).not.toContain('TOKEN_XYZ');
+    expect(out.error.message).toContain('Set-Cookie: [REDACTED]');
+    expect(out.error.message).toContain('HttpOnly');
+    expect(out.error.message).toContain('Secure');
+  });
+
+  it('redacts secrets inside string elements of arrays (truncation flag no longer needed)', () => {
+    const out = sanitizeErrorPayload({
+      ghost: {
+        originalMessage: ['https://x/y?key=LEAKED_1', 'https://x/y?token=LEAKED_2'],
+      },
+    });
+    expect(JSON.stringify(out)).not.toContain('LEAKED_1');
+    expect(JSON.stringify(out)).not.toContain('LEAKED_2');
+    expect(out.ghost.originalMessage[0]).toContain('key=[REDACTED]');
+    expect(out.ghost.originalMessage[1]).toContain('token=[REDACTED]');
+  });
+
   it('leaves benign content untouched', () => {
     const input = {
       error: { message: 'Title is required', code: 'GHOST_VALIDATION_ERROR', statusCode: 400 },

--- a/src/utils/__tests__/sanitizeErrorPayload.test.js
+++ b/src/utils/__tests__/sanitizeErrorPayload.test.js
@@ -105,13 +105,33 @@ describe('sanitizeErrorPayload', () => {
     expect(out).toEqual(input);
   });
 
-  it('truncates long originalMessage', () => {
+  it('truncates long originalMessage to 2KB cap', () => {
     const longMsg = 'x'.repeat(5000);
     const out = sanitizeErrorPayload({
       ghost: { originalMessage: longMsg },
     });
-    expect(out.ghost.originalMessage.length).toBeLessThan(longMsg.length);
+    // 2048-byte cap + ellipsis suffix: result stays under 2100 characters.
+    expect(out.ghost.originalMessage.length).toBeLessThan(2100);
     expect(out.ghost.originalMessage).toContain('[truncated]');
+  });
+
+  it('caps generic strings at 4KB even outside ghost.originalMessage', () => {
+    const longMsg = 'y'.repeat(10000);
+    const out = sanitizeErrorPayload({
+      error: { message: longMsg },
+    });
+    expect(out.error.message.length).toBeLessThan(4200);
+    expect(out.error.message).toContain('[truncated]');
+  });
+
+  it('redacts before truncation so sliced content cannot leak a secret prefix', () => {
+    // Secret placed near the END of a 5000-byte string, AFTER the 4 KB cap.
+    // redactString runs first during walk(); truncate runs on the redacted text.
+    const secret = `${'a'.repeat(24)}:${'b'.repeat(64)}`;
+    const msg = 'x'.repeat(4900) + secret;
+    const out = sanitizeErrorPayload({ error: { message: msg } });
+    // Secret must be redacted regardless of whether it fell on the truncated side.
+    expect(out.error.message).not.toContain(secret);
   });
 
   it('does not redact env key when env var is empty', () => {

--- a/src/utils/__tests__/sanitizeErrorPayload.test.js
+++ b/src/utils/__tests__/sanitizeErrorPayload.test.js
@@ -124,14 +124,25 @@ describe('sanitizeErrorPayload', () => {
     expect(out.error.message).toContain('[truncated]');
   });
 
-  it('redacts before truncation so sliced content cannot leak a secret prefix', () => {
-    // Secret placed near the END of a 5000-byte string, AFTER the 4 KB cap.
-    // redactString runs first during walk(); truncate runs on the redacted text.
-    const secret = `${'a'.repeat(24)}:${'b'.repeat(64)}`;
-    const msg = 'x'.repeat(4900) + secret;
+  it('redacts BEFORE truncating so secrets spanning the cap boundary cannot leak a prefix', () => {
+    // Place a 89-byte Ghost-shaped admin key so it STRADDLES the 4096-byte
+    // generic cap (starts at 4050, ends at 4139). The ordering matters only
+    // for boundary-spanning values:
+    //   redact-first → full pattern matches, entire secret becomes [REDACTED]
+    //     before truncation; no prefix of the secret remains in the output.
+    //   truncate-first → first 4096 bytes keep a 46-byte PREFIX of the secret;
+    //     GHOST_KEY_PATTERN requires the full 89 chars to match, so the
+    //     partial prefix slips past redaction and leaks.
+    const secret = `${'a'.repeat(24)}:${'b'.repeat(64)}`; // 89 bytes
+    const msg = 'x'.repeat(4050) + secret; // 4139 bytes — boundary at 4096 cuts the secret
     const out = sanitizeErrorPayload({ error: { message: msg } });
-    // Secret must be redacted regardless of whether it fell on the truncated side.
     expect(out.error.message).not.toContain(secret);
+    // The partial prefix that truncate-first would leave behind. If this
+    // appears in the output, redaction ran AFTER truncation on a string the
+    // pattern no longer matches.
+    const leakedPrefix = `${'a'.repeat(24)}:${'b'.repeat(21)}`;
+    expect(out.error.message).not.toContain(leakedPrefix);
+    expect(out.error.message).toContain('[REDACTED]');
   });
 
   it('does not redact env key when env var is empty', () => {

--- a/src/utils/__tests__/sanitizeErrorPayload.test.js
+++ b/src/utils/__tests__/sanitizeErrorPayload.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { sanitizeErrorPayload } from '../sanitizeErrorPayload.js';
+
+describe('sanitizeErrorPayload', () => {
+  const originalEnv = process.env.GHOST_ADMIN_API_KEY;
+
+  beforeEach(() => {
+    process.env.GHOST_ADMIN_API_KEY = '';
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.GHOST_ADMIN_API_KEY;
+    } else {
+      process.env.GHOST_ADMIN_API_KEY = originalEnv;
+    }
+  });
+
+  it('redacts GHOST_ADMIN_API_KEY when it appears verbatim in a nested string', () => {
+    process.env.GHOST_ADMIN_API_KEY = 'super-secret-env-key-value';
+    const input = {
+      error: { message: 'Leaked super-secret-env-key-value in text' },
+      ghost: { originalMessage: 'also super-secret-env-key-value here' },
+    };
+    const out = sanitizeErrorPayload(input);
+    expect(out.error.message).not.toContain('super-secret-env-key-value');
+    expect(out.error.message).toContain('[REDACTED]');
+    expect(out.ghost.originalMessage).not.toContain('super-secret-env-key-value');
+  });
+
+  it('redacts Ghost-shaped admin key literal embedded in text', () => {
+    const key = `${'a'.repeat(24)}:${'b'.repeat(64)}`;
+    const out = sanitizeErrorPayload({
+      error: { message: `Bad auth with ${key} failed` },
+    });
+    expect(out.error.message).not.toContain(key);
+    expect(out.error.message).toContain('[REDACTED]');
+  });
+
+  it('redacts key= token= and access_token= query params on URLs', () => {
+    const out = sanitizeErrorPayload({
+      error: { message: 'GET https://ghost.example/admin?key=abc123&other=fine' },
+      ghost: {
+        originalMessage: 'https://x/y?token=xyz and https://x/y?access_token=qqq',
+      },
+    });
+    expect(out.error.message).toContain('key=[REDACTED]');
+    expect(out.error.message).toContain('other=fine');
+    expect(out.ghost.originalMessage).toContain('token=[REDACTED]');
+    expect(out.ghost.originalMessage).toContain('access_token=[REDACTED]');
+  });
+
+  it('redacts Authorization / Cookie header-style substrings', () => {
+    const out = sanitizeErrorPayload({
+      error: { message: 'Authorization: Bearer abc.def.ghi and Cookie: sess=xyz' },
+    });
+    expect(out.error.message).not.toContain('abc.def.ghi');
+    expect(out.error.message).not.toContain('sess=xyz');
+    expect(out.error.message).toContain('Authorization');
+    expect(out.error.message).toContain('[REDACTED]');
+  });
+
+  it('leaves benign content untouched', () => {
+    const input = {
+      error: { message: 'Title is required', code: 'GHOST_VALIDATION_ERROR', statusCode: 400 },
+      ghost: {
+        operation: 'posts.edit',
+        statusCode: 422,
+        originalMessage: 'Post title cannot be blank',
+      },
+    };
+    const out = sanitizeErrorPayload(input);
+    expect(out).toEqual(input);
+  });
+
+  it('truncates long originalMessage', () => {
+    const longMsg = 'x'.repeat(5000);
+    const out = sanitizeErrorPayload({
+      ghost: { originalMessage: longMsg },
+    });
+    expect(out.ghost.originalMessage.length).toBeLessThan(longMsg.length);
+    expect(out.ghost.originalMessage).toContain('[truncated]');
+  });
+
+  it('does not redact env key when env var is empty', () => {
+    process.env.GHOST_ADMIN_API_KEY = '';
+    const out = sanitizeErrorPayload({ error: { message: 'harmless text' } });
+    expect(out.error.message).toBe('harmless text');
+  });
+
+  it('does not mutate the input object', () => {
+    process.env.GHOST_ADMIN_API_KEY = 'SECRET';
+    const input = { error: { message: 'contains SECRET' } };
+    const snapshot = JSON.parse(JSON.stringify(input));
+    sanitizeErrorPayload(input);
+    expect(input).toEqual(snapshot);
+  });
+});

--- a/src/utils/__tests__/validation.test.js
+++ b/src/utils/__tests__/validation.test.js
@@ -54,11 +54,14 @@ describe('validateToolInput', () => {
       const result = validateToolInput(testSchema, { name: '' }, 'test_tool');
 
       expect(result.success).toBe(false);
-      const errorObj = JSON.parse(result.errorResponse.content[0].text);
-      expect(errorObj.name).toBe('ValidationError');
-      expect(errorObj.code).toBe('VALIDATION_ERROR');
-      expect(errorObj.statusCode).toBe(400);
-      expect(errorObj.message).toContain('Validation failed');
+      const text = result.errorResponse.content[0].text;
+      const jsonMatch = text.match(/```json\n([\s\S]+?)\n```/);
+      expect(jsonMatch).toBeTruthy();
+      const envelope = JSON.parse(jsonMatch[1]);
+      expect(envelope.error.name).toBe('ValidationError');
+      expect(envelope.error.code).toBe('VALIDATION_ERROR');
+      expect(envelope.error.statusCode).toBe(400);
+      expect(envelope.error.message).toContain('Validation failed');
     });
   });
 
@@ -141,8 +144,11 @@ describe('validateToolInput', () => {
 
       expect(result.success).toBe(false);
       expect(result.errorResponse.isError).toBe(true);
-      const errorObj = JSON.parse(result.errorResponse.content[0].text);
-      expect(errorObj.code).toBe('VALIDATION_ERROR');
+      const text = result.errorResponse.content[0].text;
+      const jsonMatch = text.match(/```json\n([\s\S]+?)\n```/);
+      expect(jsonMatch).toBeTruthy();
+      const envelope = JSON.parse(jsonMatch[1]);
+      expect(envelope.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('should pass validation when refinement is satisfied', () => {

--- a/src/utils/formatErrorResponse.js
+++ b/src/utils/formatErrorResponse.js
@@ -42,7 +42,9 @@ export function formatErrorResponse(error, toolName, extra) {
     };
   }
 
-  if (extra && Object.keys(extra).length > 0) {
+  // Guard against non-object `extra`: Object.keys(string) returns per-char
+  // indices and would silently set envelope.extra to that string.
+  if (extra && typeof extra === 'object' && Object.keys(extra).length > 0) {
     envelope.extra = extra;
   }
 

--- a/src/utils/formatErrorResponse.js
+++ b/src/utils/formatErrorResponse.js
@@ -36,16 +36,13 @@ export function formatErrorResponse(error, toolName, extra) {
     envelope.ghost = {
       operation: normalized.operation,
       statusCode: normalized.ghostStatusCode,
-      // normalized.originalError is already a string (coerced by ExternalServiceError constructor);
-      // coerce again defensively so the sanitizer always receives a string, not an Error object.
-      originalMessage:
-        typeof normalized.originalError === 'string'
-          ? normalized.originalError
-          : (normalized.originalError?.message ?? String(normalized.originalError)),
+      // ExternalServiceError's constructor coerces originalError to a string;
+      // String() handles any surprise non-string value without branching.
+      originalMessage: String(normalized.originalError ?? ''),
     };
   }
 
-  if (extra && typeof extra === 'object' && Object.keys(extra).length > 0) {
+  if (extra && Object.keys(extra).length > 0) {
     envelope.extra = extra;
   }
 

--- a/src/utils/formatErrorResponse.js
+++ b/src/utils/formatErrorResponse.js
@@ -1,0 +1,51 @@
+import { BaseError, GhostAPIError } from '../errors/index.js';
+import { sanitizeErrorPayload } from './sanitizeErrorPayload.js';
+
+/**
+ * Builds an MCP tool error response with a consistent envelope shape.
+ * All errors produce `{ error: {...} }`; GhostAPIError additionally includes
+ * a gated `ghost` sub-object with Ghost-specific diagnostic fields.
+ * The envelope is passed through sanitizeErrorPayload before emission.
+ *
+ * @param {Error} error - The caught error.
+ * @param {string} toolName - MCP tool name for the human-readable summary line.
+ * @returns {{content: {type: string, text: string}[], isError: true}}
+ */
+export function formatErrorResponse(error, toolName) {
+  const base =
+    error instanceof BaseError
+      ? error.toJSON()
+      : {
+          name: error?.name || 'Error',
+          message: error?.message || String(error),
+          code: 'UNKNOWN',
+          statusCode: 500,
+        };
+
+  const envelope = { error: base };
+
+  if (error instanceof GhostAPIError) {
+    envelope.ghost = {
+      operation: error.operation,
+      statusCode: error.ghostStatusCode,
+      // error.originalError is already a string (coerced by ExternalServiceError constructor);
+      // coerce again defensively so the sanitizer always receives a string, not an Error object.
+      originalMessage:
+        typeof error.originalError === 'string'
+          ? error.originalError
+          : (error.originalError?.message ?? String(error.originalError)),
+    };
+  }
+
+  const sanitized = sanitizeErrorPayload(envelope);
+  const summary = sanitized.ghost
+    ? `Error in ${toolName}: ${sanitized.error.name} [${sanitized.ghost.statusCode ?? '?'} ${sanitized.error.code}] ${sanitized.ghost.operation ?? '?'}: ${sanitized.ghost.originalMessage ?? sanitized.error.message}`
+    : `Error in ${toolName}: ${sanitized.error.message}`;
+
+  const body = `${summary}\n\n\`\`\`json\n${JSON.stringify(sanitized, null, 2)}\n\`\`\``;
+
+  return {
+    content: [{ type: 'text', text: body }],
+    isError: true,
+  };
+}

--- a/src/utils/formatErrorResponse.js
+++ b/src/utils/formatErrorResponse.js
@@ -1,40 +1,52 @@
-import { BaseError, GhostAPIError } from '../errors/index.js';
+import { BaseError, GhostAPIError, ValidationError } from '../errors/index.js';
 import { sanitizeErrorPayload } from './sanitizeErrorPayload.js';
 
 /**
  * Builds an MCP tool error response with a consistent envelope shape.
  * All errors produce `{ error: {...} }`; GhostAPIError additionally includes
- * a gated `ghost` sub-object with Ghost-specific diagnostic fields.
- * The envelope is passed through sanitizeErrorPayload before emission.
+ * a gated `ghost` sub-object with Ghost-specific diagnostic fields. Callers
+ * may pass an optional `extra` object whose contents will be merged into the
+ * envelope under an `extra` key and sanitized alongside the rest.
  *
  * @param {Error} error - The caught error.
  * @param {string} toolName - MCP tool name for the human-readable summary line.
+ * @param {object} [extra] - Optional caller-supplied context; sanitized with the envelope.
  * @returns {{content: {type: string, text: string}[], isError: true}}
  */
-export function formatErrorResponse(error, toolName) {
+export function formatErrorResponse(error, toolName, extra) {
+  // Duck-type ZodError so we don't couple this module to the zod runtime.
+  const normalized =
+    error?.name === 'ZodError' && Array.isArray(error.issues)
+      ? ValidationError.fromZod(error, toolName)
+      : error;
+
   const base =
-    error instanceof BaseError
-      ? error.toJSON()
+    normalized instanceof BaseError
+      ? normalized.toJSON()
       : {
-          name: error?.name || 'Error',
-          message: error?.message || String(error),
+          name: normalized?.name || 'Error',
+          message: normalized?.message || String(normalized),
           code: 'UNKNOWN',
           statusCode: 500,
         };
 
   const envelope = { error: base };
 
-  if (error instanceof GhostAPIError) {
+  if (normalized instanceof GhostAPIError) {
     envelope.ghost = {
-      operation: error.operation,
-      statusCode: error.ghostStatusCode,
-      // error.originalError is already a string (coerced by ExternalServiceError constructor);
+      operation: normalized.operation,
+      statusCode: normalized.ghostStatusCode,
+      // normalized.originalError is already a string (coerced by ExternalServiceError constructor);
       // coerce again defensively so the sanitizer always receives a string, not an Error object.
       originalMessage:
-        typeof error.originalError === 'string'
-          ? error.originalError
-          : (error.originalError?.message ?? String(error.originalError)),
+        typeof normalized.originalError === 'string'
+          ? normalized.originalError
+          : (normalized.originalError?.message ?? String(normalized.originalError)),
     };
+  }
+
+  if (extra && typeof extra === 'object' && Object.keys(extra).length > 0) {
+    envelope.extra = extra;
   }
 
   const sanitized = sanitizeErrorPayload(envelope);

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -43,15 +43,21 @@ const logger = winston.createLogger({
     pid: process.pid,
   },
   transports: [
-    // Console output
+    // Console output — route all levels to stderr so stdio MCP transport
+    // (which uses stdout for JSON-RPC frames) is not corrupted by log lines.
     new winston.transports.Console({
       level: isDevelopment ? 'debug' : 'info',
+      stderrLevels: ['error', 'warn', 'info', 'debug'],
     }),
   ],
   // Handle uncaught exceptions
-  exceptionHandlers: [new winston.transports.Console()],
+  exceptionHandlers: [
+    new winston.transports.Console({ stderrLevels: ['error', 'warn', 'info', 'debug'] }),
+  ],
   // Handle unhandled promise rejections
-  rejectionHandlers: [new winston.transports.Console()],
+  rejectionHandlers: [
+    new winston.transports.Console({ stderrLevels: ['error', 'warn', 'info', 'debug'] }),
+  ],
 });
 
 // Add file logging in production

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -9,6 +9,11 @@ const __dirname = path.dirname(__filename);
 const logLevel = process.env.LOG_LEVEL || 'info';
 const isDevelopment = process.env.NODE_ENV === 'development';
 
+// Every level winston emits must route to stderr — the stdio MCP transport
+// reserves stdout for JSON-RPC frames. Single source of truth so adding a new
+// level later can't silently leave one transport routing to stdout.
+const ALL_LEVELS_TO_STDERR = ['error', 'warn', 'info', 'debug'];
+
 // Define custom log format
 const logFormat = winston.format.combine(
   winston.format.timestamp({
@@ -47,17 +52,13 @@ const logger = winston.createLogger({
     // (which uses stdout for JSON-RPC frames) is not corrupted by log lines.
     new winston.transports.Console({
       level: isDevelopment ? 'debug' : 'info',
-      stderrLevels: ['error', 'warn', 'info', 'debug'],
+      stderrLevels: ALL_LEVELS_TO_STDERR,
     }),
   ],
   // Handle uncaught exceptions
-  exceptionHandlers: [
-    new winston.transports.Console({ stderrLevels: ['error', 'warn', 'info', 'debug'] }),
-  ],
+  exceptionHandlers: [new winston.transports.Console({ stderrLevels: ALL_LEVELS_TO_STDERR })],
   // Handle unhandled promise rejections
-  rejectionHandlers: [
-    new winston.transports.Console({ stderrLevels: ['error', 'warn', 'info', 'debug'] }),
-  ],
+  rejectionHandlers: [new winston.transports.Console({ stderrLevels: ALL_LEVELS_TO_STDERR })],
 });
 
 // Add file logging in production

--- a/src/utils/sanitizeErrorPayload.js
+++ b/src/utils/sanitizeErrorPayload.js
@@ -5,7 +5,14 @@
 
 const GHOST_KEY_PATTERN = /[0-9a-f]{24}:[0-9a-f]{64}/gi;
 const URL_SECRET_QS_PATTERN = /([?&](?:key|token|access_token)=)[^&\s"']+/gi;
-const AUTH_HEADER_PATTERN = /(Authorization|Cookie|Set-Cookie)\s*[:=]\s*[^\r\n,;]+/gi;
+// Authorization / Set-Cookie values stop at ';' (Set-Cookie attributes like
+// HttpOnly/Secure are not secrets). A bare `Cookie` header can contain multiple
+// `name=value` pairs separated by ';' — all of which may be session tokens — so
+// it gets a separate, greedier pattern that stops only at end-of-line.
+const AUTH_HEADER_PATTERN = /(Authorization|Set-Cookie)\s*[:=]\s*[^\r\n,;]+/gi;
+// Negative look-behind so this pattern matches a bare `Cookie:` header but not
+// the `Cookie` substring inside `Set-Cookie:` (handled by AUTH_HEADER_PATTERN).
+const COOKIE_HEADER_PATTERN = /(?<!Set-)(Cookie)\s*[:=]\s*[^\r\n]+/gi;
 const REDACTED = '[REDACTED]';
 const ORIGINAL_MESSAGE_MAX_BYTES = 2048;
 
@@ -18,6 +25,7 @@ function redactString(value, envKey) {
   out = out.replace(GHOST_KEY_PATTERN, REDACTED);
   out = out.replace(URL_SECRET_QS_PATTERN, `$1${REDACTED}`);
   out = out.replace(AUTH_HEADER_PATTERN, `$1: ${REDACTED}`);
+  out = out.replace(COOKIE_HEADER_PATTERN, `$1: ${REDACTED}`);
   return out;
 }
 
@@ -28,19 +36,18 @@ function truncate(value, maxBytes) {
   return `${Buffer.from(value, 'utf8').subarray(0, maxBytes).toString('utf8')}…[truncated]`;
 }
 
-function walk(node, envKey, isOriginalMessage = false) {
+function walk(node, envKey) {
   if (node === null || node === undefined) return node;
-  if (typeof node === 'string') {
-    const redacted = redactString(node, envKey);
-    return isOriginalMessage ? truncate(redacted, ORIGINAL_MESSAGE_MAX_BYTES) : redacted;
-  }
-  if (Array.isArray(node)) {
-    return node.map((item) => walk(item, envKey));
-  }
+  if (typeof node === 'string') return redactString(node, envKey);
+  if (Array.isArray(node)) return node.map((item) => walk(item, envKey));
   if (typeof node === 'object') {
     const result = {};
     for (const [k, v] of Object.entries(node)) {
-      result[k] = walk(v, envKey, k === 'originalMessage');
+      const walked = walk(v, envKey);
+      result[k] =
+        k === 'originalMessage' && typeof walked === 'string'
+          ? truncate(walked, ORIGINAL_MESSAGE_MAX_BYTES)
+          : walked;
     }
     return result;
   }

--- a/src/utils/sanitizeErrorPayload.js
+++ b/src/utils/sanitizeErrorPayload.js
@@ -1,0 +1,60 @@
+/**
+ * Sole chokepoint for sanitizing error payloads surfaced to MCP clients.
+ * Walks the envelope and replaces values that could leak credentials.
+ */
+
+const GHOST_KEY_PATTERN = /[0-9a-f]{24}:[0-9a-f]{64}/gi;
+const URL_SECRET_QS_PATTERN = /([?&](?:key|token|access_token)=)[^&\s"']+/gi;
+const AUTH_HEADER_PATTERN = /(Authorization|Cookie|Set-Cookie)\s*[:=]\s*[^\r\n,;]+/gi;
+const REDACTED = '[REDACTED]';
+const ORIGINAL_MESSAGE_MAX_BYTES = 2048;
+
+function redactString(value, envKey) {
+  if (typeof value !== 'string' || value.length === 0) return value;
+  let out = value;
+  if (envKey) {
+    out = out.replaceAll(envKey, REDACTED);
+  }
+  out = out.replace(GHOST_KEY_PATTERN, REDACTED);
+  out = out.replace(URL_SECRET_QS_PATTERN, `$1${REDACTED}`);
+  out = out.replace(AUTH_HEADER_PATTERN, `$1: ${REDACTED}`);
+  return out;
+}
+
+function truncate(value, maxBytes) {
+  if (typeof value !== 'string') return value;
+  if (Buffer.byteLength(value, 'utf8') <= maxBytes) return value;
+  // Slice by bytes (not chars) to honour the byte limit even for multibyte content.
+  return `${Buffer.from(value, 'utf8').subarray(0, maxBytes).toString('utf8')}…[truncated]`;
+}
+
+function walk(node, envKey, isOriginalMessage = false) {
+  if (node === null || node === undefined) return node;
+  if (typeof node === 'string') {
+    const redacted = redactString(node, envKey);
+    return isOriginalMessage ? truncate(redacted, ORIGINAL_MESSAGE_MAX_BYTES) : redacted;
+  }
+  if (Array.isArray(node)) {
+    return node.map((item) => walk(item, envKey));
+  }
+  if (typeof node === 'object') {
+    const result = {};
+    for (const [k, v] of Object.entries(node)) {
+      result[k] = walk(v, envKey, k === 'originalMessage');
+    }
+    return result;
+  }
+  return node;
+}
+
+/**
+ * Deep-walks an error envelope and redacts known secret patterns.
+ * Non-destructive: returns a new object; does not mutate input.
+ *
+ * @param {object} envelope - Error envelope object.
+ * @returns {object} Sanitized envelope.
+ */
+export function sanitizeErrorPayload(envelope) {
+  const envKey = process.env.GHOST_ADMIN_API_KEY || '';
+  return walk(envelope, envKey);
+}

--- a/src/utils/sanitizeErrorPayload.js
+++ b/src/utils/sanitizeErrorPayload.js
@@ -14,6 +14,10 @@ const AUTH_HEADER_PATTERN = /(Authorization|Set-Cookie)\s*[:=]\s*[^\r\n,;]+/gi;
 // the `Cookie` substring inside `Set-Cookie:` (handled by AUTH_HEADER_PATTERN).
 const COOKIE_HEADER_PATTERN = /(?<!Set-)(Cookie)\s*[:=]\s*[^\r\n]+/gi;
 const REDACTED = '[REDACTED]';
+// Upper bound on any string value in the envelope (guards against pathological
+// Ghost responses bloating the MCP reply).
+const GENERIC_MAX_BYTES = 4096;
+// Tighter cap on `ghost.originalMessage` specifically.
 const ORIGINAL_MESSAGE_MAX_BYTES = 2048;
 
 function redactString(value, envKey) {
@@ -38,16 +42,12 @@ function truncate(value, maxBytes) {
 
 function walk(node, envKey) {
   if (node === null || node === undefined) return node;
-  if (typeof node === 'string') return redactString(node, envKey);
+  if (typeof node === 'string') return truncate(redactString(node, envKey), GENERIC_MAX_BYTES);
   if (Array.isArray(node)) return node.map((item) => walk(item, envKey));
   if (typeof node === 'object') {
     const result = {};
     for (const [k, v] of Object.entries(node)) {
-      const walked = walk(v, envKey);
-      result[k] =
-        k === 'originalMessage' && typeof walked === 'string'
-          ? truncate(walked, ORIGINAL_MESSAGE_MAX_BYTES)
-          : walked;
+      result[k] = walk(v, envKey);
     }
     return result;
   }
@@ -63,5 +63,15 @@ function walk(node, envKey) {
  */
 export function sanitizeErrorPayload(envelope) {
   const envKey = process.env.GHOST_ADMIN_API_KEY || '';
-  return walk(envelope, envKey);
+  const sanitized = walk(envelope, envKey);
+  // Tighter cap for ghost.originalMessage specifically. walk() already applied
+  // the 4 KB generic cap; this narrows it further on the field most likely to
+  // receive a verbose Ghost response body.
+  if (sanitized?.ghost && typeof sanitized.ghost.originalMessage === 'string') {
+    sanitized.ghost.originalMessage = truncate(
+      sanitized.ghost.originalMessage,
+      ORIGINAL_MESSAGE_MAX_BYTES
+    );
+  }
+  return sanitized;
 }

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -2,7 +2,6 @@
  * Validation utilities for MCP tool handlers
  * Provides explicit Zod validation to ensure input is validated at handler entry points.
  */
-import { ValidationError } from '../errors/index.js';
 import { formatErrorResponse } from './formatErrorResponse.js';
 
 /**
@@ -16,10 +15,11 @@ import { formatErrorResponse } from './formatErrorResponse.js';
 export const validateToolInput = (schema, input, toolName) => {
   const result = schema.safeParse(input);
   if (!result.success) {
-    const error = ValidationError.fromZod(result.error, toolName);
+    // formatErrorResponse duck-types ZodError and coerces it to ValidationError,
+    // so pass the raw ZodError through — it owns the single coercion path.
     return {
       success: false,
-      errorResponse: formatErrorResponse(error, toolName),
+      errorResponse: formatErrorResponse(result.error, toolName),
     };
   }
   return { success: true, data: result.data };

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -3,6 +3,7 @@
  * Provides explicit Zod validation to ensure input is validated at handler entry points.
  */
 import { ValidationError } from '../errors/index.js';
+import { formatErrorResponse } from './formatErrorResponse.js';
 
 /**
  * Validates tool input against a Zod schema and returns a structured result.
@@ -18,10 +19,7 @@ export const validateToolInput = (schema, input, toolName) => {
     const error = ValidationError.fromZod(result.error, toolName);
     return {
       success: false,
-      errorResponse: {
-        content: [{ type: 'text', text: JSON.stringify(error.toJSON(), null, 2) }],
-        isError: true,
-      },
+      errorResponse: formatErrorResponse(error, toolName),
     };
   }
   return { success: true, data: result.data };


### PR DESCRIPTION
## Summary

This PR improves observability and error handling across the MCP server by replacing debug-level `console.error()` calls with proper `mcpLogger.info()` logging, enhancing error sanitization to prevent secret leakage at truncation boundaries, and removing an unused UUID generation helper.

## Key Changes

- **Logging improvements**: Replaced ~30 `console.error()` calls with `mcpLogger.info()` throughout tool handlers (tags, posts, pages, members, newsletters) to use the proper logging infrastructure instead of stderr debug output.

- **Logger transport routing**: Configured Winston's Console transport to route all log levels (error, warn, info, debug) to stderr via `stderrLevels`, preventing log output from corrupting the stdio MCP transport's stdout JSON-RPC channel. Added comprehensive tests verifying this routing.

- **Enhanced error sanitization**:
  - Added 4KB generic cap on all string values in error envelopes to guard against pathological Ghost responses bloating MCP replies
  - Fixed critical ordering bug: redaction now runs **before** truncation, preventing secrets that span the truncation boundary from leaking a prefix in the output
  - Extended redaction patterns to include `Set-Cookie` and bare `Cookie` headers (session tokens)
  - Added test case demonstrating the boundary-spanning secret scenario

- **Error response improvements**:
  - `formatErrorResponse` now accepts optional `extra` context object for caller-supplied context
  - Simplified `ghost.originalMessage` coercion logic with defensive `String()` conversion
  - Updated `validateAndXorImageInput` to use `formatErrorResponse` for consistent error envelope shape

- **Removed unused code**: Deleted `generateUuid()` helper function; callers now use `crypto.randomUUID()` directly (2 occurrences).

- **Validation refactoring**: `validateToolInput` now passes raw ZodError to `formatErrorResponse` instead of pre-coercing to ValidationError, establishing a single coercion path.

- **Documentation updates**: Updated CLAUDE.md and ERROR_HANDLING.md to reflect enhanced error sanitization capabilities and logging practices.

## Notable Implementation Details

- The redaction-before-truncation fix is critical for security: a 89-byte Ghost-shaped admin key pattern straddling a 4096-byte boundary would previously leak a 46-byte prefix if truncation ran first.
- Logger transport routing uses Node internals (`console._stdout`/`console._stderr`) that Winston's Console transport captures at construction time; tests verify these assumptions with explicit error handling.
- All log levels now consistently route to stderr, making the logger safe for use in stdio MCP transport contexts.

https://claude.ai/code/session_017EaCiRbzzXW47eRCid4Hxb