### PR TITLE
chore: layered defense for project invariants (hooks + ESLint + factory)

### DIFF
--- a/.claude/hooks/block-dangerous-git.sh
+++ b/.claude/hooks/block-dangerous-git.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Bash. Blocks dangerous git invocations that bypass
+# project safety gates: --no-verify (skips Husky lint/test) and --force on
+# push (--force-with-lease is allowed because it's safe in normal usage).
+#
+# We shell-tokenize the command (Python shlex) and only match flags that
+# appear as top-level argv tokens — substring matches inside quoted message
+# bodies don't trigger the hook.
+#
+# Input: JSON on stdin: { tool_input: { command: "..." }, ... }
+# Output: exit 0 = allow; exit 2 + stderr message = block.
+#
+# Bypass: GHOST_MCP_HOOK_BYPASS=1 (logged to stderr).
+
+set -u
+
+input="$(cat)"
+
+if [[ "${GHOST_MCP_HOOK_BYPASS:-}" == "1" ]]; then
+  echo "[hook bypass] block-dangerous-git.sh skipped via GHOST_MCP_HOOK_BYPASS=1" >&2
+  exit 0
+fi
+
+result=$(HOOK_INPUT="$input" python3 - <<'PY'
+import json, shlex, os, sys
+
+raw = os.environ.get("HOOK_INPUT", "")
+try:
+    data = json.loads(raw) if raw else {}
+except Exception:
+    print("ALLOW")
+    sys.exit(0)
+
+command = data.get("tool_input", {}).get("command", "") or ""
+if not command:
+    print("ALLOW")
+    sys.exit(0)
+
+# Split on shell command separators so chained commands are checked too.
+# Conservative: any of && || ; | starts a fresh command.
+import re
+segments = re.split(r"(?:&&|\|\||;|\|)", command)
+
+def check(segment):
+    seg = segment.strip()
+    if not seg:
+        return None
+    try:
+        tokens = shlex.split(seg, posix=True)
+    except ValueError:
+        return None  # unbalanced quotes — let it through, lint-staged will catch real issues
+
+    if len(tokens) < 2 or tokens[0] != "git":
+        return None
+
+    sub = tokens[1]
+
+    if sub in ("commit", "push") and "--no-verify" in tokens[2:]:
+        return "NO_VERIFY"
+
+    if sub == "push" and "--force" in tokens[2:] and not any(
+        t == "--force-with-lease" or t.startswith("--force-with-lease=") for t in tokens[2:]
+    ):
+        return "FORCE_PUSH"
+
+    return None
+
+for seg in segments:
+    verdict = check(seg)
+    if verdict:
+        print(verdict)
+        sys.exit(0)
+
+print("ALLOW")
+PY
+)
+
+case "$result" in
+  NO_VERIFY)
+    cat >&2 <<'EOF'
+Blocked: --no-verify bypasses Husky pre-commit (lint-staged) / pre-push (npm test).
+Per CLAUDE.md, fix the failing lint/test instead. If absolutely necessary,
+set GHOST_MCP_HOOK_BYPASS=1 and try again — the bypass is logged.
+EOF
+    exit 2
+    ;;
+  FORCE_PUSH)
+    cat >&2 <<'EOF'
+Blocked: `git push --force` can clobber upstream history. Use
+`git push --force-with-lease` instead, which refuses the push if the remote
+has moved unexpectedly. Set GHOST_MCP_HOOK_BYPASS=1 to override.
+EOF
+    exit 2
+    ;;
+  *)
+    exit 0
+    ;;
+esac

--- a/.claude/hooks/block-main-branch-edits.sh
+++ b/.claude/hooks/block-main-branch-edits.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Edit / Write / Bash that mutates the working tree.
+# Refuses edits while HEAD is `main`. The SessionStart hook H0 already warns
+# at startup; this is the safety net so a forgotten warning becomes a hard stop
+# rather than a lost commit.
+#
+# Input: JSON on stdin with `tool_name` and `tool_input`.
+# Output: exit 0 = allow; exit 2 + stderr = block.
+#
+# Bypass: GHOST_MCP_HOOK_BYPASS=1 (logged to stderr).
+
+set -u
+
+input="$(cat)"
+
+if [[ "${GHOST_MCP_HOOK_BYPASS:-}" == "1" ]]; then
+  echo "[hook bypass] block-main-branch-edits.sh skipped via GHOST_MCP_HOOK_BYPASS=1" >&2
+  exit 0
+fi
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+branch="$(git -C "$repo_root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
+
+if [[ "$branch" != "main" ]]; then
+  exit 0
+fi
+
+# Only block Bash that's a write command (commit, push). Reads (status, log,
+# diff, branch lookup) are still useful on main.
+tool_name=$(printf '%s' "$input" | python3 -c '
+import json, sys
+try:
+    print(json.load(sys.stdin).get("tool_name", ""))
+except Exception:
+    print("")
+')
+
+if [[ "$tool_name" == "Bash" ]]; then
+  command=$(printf '%s' "$input" | python3 -c '
+import json, sys
+try:
+    print(json.load(sys.stdin).get("tool_input", {}).get("command", ""))
+except Exception:
+    print("")
+')
+  # Allow read-only git operations and the branch-creating one.
+  if [[ "$command" =~ git[[:space:]]+(commit|push|merge|rebase) ]]; then
+    cat >&2 <<EOF
+Blocked: HEAD is on \`main\` and \`$command\` would mutate \`main\`.
+CLAUDE.md requires a feature branch:
+  git checkout -b <type>/<short-description>
+Then retry. Set GHOST_MCP_HOOK_BYPASS=1 to override.
+EOF
+    exit 2
+  fi
+  exit 0
+fi
+
+# Edit / Write tools: always blocked on main.
+cat >&2 <<EOF
+Blocked: HEAD is on \`main\`. CLAUDE.md requires a feature branch before any
+file modification:
+  git checkout -b <type>/<short-description>
+Then retry the edit. Set GHOST_MCP_HOOK_BYPASS=1 to override.
+EOF
+exit 2

--- a/.claude/hooks/block-mcp-resources.sh
+++ b/.claude/hooks/block-mcp-resources.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Edit / Write. Refuses changes to src/mcp_server*.js
+# that try to register MCP resources or resource handlers. The canonical
+# server is tools-only by product decision (see CLAUDE.md, phase3 plan).
+#
+# Input: JSON on stdin with `tool_name` and `tool_input` (file_path, new_string
+# for Edit; file_path, content for Write).
+# Output: exit 0 = allow; exit 2 + stderr = block.
+#
+# Bypass: GHOST_MCP_HOOK_BYPASS=1 (logged to stderr).
+
+set -u
+
+input="$(cat)"
+
+if [[ "${GHOST_MCP_HOOK_BYPASS:-}" == "1" ]]; then
+  echo "[hook bypass] block-mcp-resources.sh skipped via GHOST_MCP_HOOK_BYPASS=1" >&2
+  exit 0
+fi
+
+read -r file_path payload < <(printf '%s' "$input" | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    tool = data.get("tool_name", "")
+    ti = data.get("tool_input", {}) or {}
+    fp = ti.get("file_path", "")
+    if tool == "Edit":
+        payload = ti.get("new_string", "")
+    elif tool == "Write":
+        payload = ti.get("content", "")
+    elif tool == "MultiEdit":
+        edits = ti.get("edits", []) or []
+        payload = "\n".join(e.get("new_string", "") for e in edits)
+    else:
+        payload = ""
+    # Strip newlines so we can pass on a single line.
+    print(fp, "\x00" + payload.replace("\n", " ").replace("\r", " "))
+except Exception:
+    print("")
+')
+
+# Only matters for src/mcp_server*.js
+if [[ ! "$file_path" =~ src/mcp_server.*\.js$ ]]; then
+  exit 0
+fi
+
+# Strip the null sentinel
+payload="${payload#$'\x00'}"
+
+# Match resource registration calls.
+if [[ "$payload" =~ (server|mcp)\.resource\( ]] \
+  || [[ "$payload" =~ registerResource\( ]] \
+  || [[ "$payload" =~ setResourceHandler\( ]] \
+  || [[ "$payload" =~ ListResourcesRequestSchema ]] \
+  || [[ "$payload" =~ ReadResourceRequestSchema ]]; then
+  cat >&2 <<EOF
+Blocked: $file_path appears to register an MCP resource or resource handler.
+The canonical Ghost MCP server is tools-only by design (CLAUDE.md, phase3 plan).
+Resource support belongs in the experimental enhanced server, not the
+canonical one. Set GHOST_MCP_HOOK_BYPASS=1 if this is intentional.
+EOF
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/session-start-branch-check.sh
+++ b/.claude/hooks/session-start-branch-check.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# SessionStart hook: warn Claude when the current branch is `main`.
+#
+# Branch protection on `main` rejects commits server-side, and the
+# stash/checkout dance after a rejected commit wastes tokens. Catching
+# the situation at session start is the cheapest possible moment.
+#
+# Output: JSON envelope per Claude Code SessionStart hook schema
+# (https://code.claude.com/docs/en/hooks.md). `additionalContext` is
+# injected into Claude's startup context.
+#
+# Exit codes: 0 always — this hook is informational, never blocking.
+
+set -u
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+branch="$(git -C "$repo_root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
+
+if [[ "$branch" != "main" ]]; then
+  printf '{"continue":true}\n'
+  exit 0
+fi
+
+read -r -d '' context <<'EOF' || true
+You are currently on the `main` branch.
+
+Branch protection is enabled on `main`, so direct commits will be rejected by the server. Per CLAUDE.md, all work must happen on a feature branch named `<type>/issue-NN-<description>` (types: feature, fix, docs, refactor, test).
+
+Before any Edit, Write, or Bash that mutates files in this repo:
+1. Confirm the work scope with the user (or infer it from their request).
+2. Run `git checkout -b <type>/<short-description>` to move off `main`.
+3. Then proceed with edits.
+
+If the user only asked you to read or explore, no branch is needed.
+EOF
+
+# Emit JSON. Use python for safe string escaping.
+python3 - "$context" <<'PY'
+import json, sys
+print(json.dumps({
+    "continue": True,
+    "hookSpecificOutput": {
+        "hookEventName": "SessionStart",
+        "additionalContext": sys.argv[1],
+    },
+}))
+PY
+
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -31,9 +31,10 @@ tasks/
 # AI working directories
 thoughts/
 
-# Claude Code per-user settings (shared settings.json stays tracked)
+# Claude Code per-user settings. Hook scripts under .claude/hooks/ are
+# tracked (cross-machine continuity for hooks Claude Code uses); only the
+# user-specific permission state and per-user plans/worktrees are ignored.
 .claude/settings.local.json
-.claude/hooks/
 .claude/plans/
 .claude/worktrees/
 

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ thoughts/
 
 # Claude Code per-user settings (shared settings.json stays tracked)
 .claude/settings.local.json
+.claude/hooks/
+.claude/plans/
+.claude/worktrees/
 
 # Test coverage
 coverage/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ All code written for this project MUST follow OWASP security best practices to p
 - `express-rate-limit` - Rate limiting
 - `crypto` - Secure random generation and comparisons
 - `helmet` - HTTP security headers
-- `joi` - Legacy validation (used in some REST endpoints; do not use for new code — prefer Zod schemas)
+- `joi` - Legacy validation, allowlisted in 4 specific files only. New `joi` imports are blocked by ESLint `no-restricted-imports` — see `eslint.config.js`. Use Zod schemas under `src/schemas/`.
 
 ## Git Workflow (Required)
 
@@ -78,7 +78,7 @@ git checkout -b <type>/issue-<number>-<description>
 2. **Make changes** on the feature branch
 3. **Commit** with clear, descriptive messages
 4. **Push** to remote and create a pull request
-5. **Never commit directly to `main`** - all changes must go through PRs
+5. **Never commit directly to `main`** - branch protection on the remote enforces this, plus a SessionStart hook (`.claude/hooks/session-start-branch-check.sh`) and a PreToolUse hook (`.claude/hooks/block-main-branch-edits.sh`) catch the situation locally before any tokens are spent.
 
 ## Project Overview
 
@@ -168,7 +168,7 @@ Follow these principles when writing code:
    - Implements Model Context Protocol specification with Zod validation
    - Exposes Ghost CMS functionality as 35 MCP tools across 7 domain types
    - Domain types: Posts, Pages, Tags, Members, Newsletters, Tiers, Images
-   - **Note:** This server provides tools only, not MCP protocol resources
+   - **Note:** This server provides tools only, not MCP protocol resources. A PreToolUse hook (`.claude/hooks/block-mcp-resources.sh`) refuses edits to `src/mcp_server*.js` that try to register resources.
    - Tools by domain:
      - **Posts** (6): `ghost_create_post`, `ghost_get_posts`, `ghost_get_post`, `ghost_search_posts`, `ghost_update_post`, `ghost_delete_post`
      - **Pages** (6): `ghost_create_page`, `ghost_get_pages`, `ghost_get_page`, `ghost_search_pages`, `ghost_update_page`, `ghost_delete_page`
@@ -199,7 +199,7 @@ Follow these principles when writing code:
    - `images.js`: Image upload to Ghost CMS (single path for all upload modes; used by imageController and MCP tools)
    - `imageProcessingService.js`: Image optimization and processing (preserves original format; does not convert to JPEG)
 
-   **Service Import Pattern:** Services in the MCP server use lazy loading to avoid Node.js ESM compatibility issues. Always use the lazy-loaded service variables from `loadServices()`. Never add inline dynamic imports. See [docs/SERVICE_PATTERNS.md](docs/SERVICE_PATTERNS.md) for detailed guidelines.
+   **Service Import Pattern:** Services in the MCP server use lazy loading via `loadServices()` to avoid Node.js ESM compatibility issues. Inline dynamic imports of any service module are blocked by ESLint `no-restricted-syntax` — see `eslint.config.js`. Detailed guidelines: [docs/SERVICE_PATTERNS.md](docs/SERVICE_PATTERNS.md).
 
 5. **Controllers** (`src/controllers/`):
    - Handle HTTP requests for posts, images, and tags
@@ -219,7 +219,7 @@ Follow these principles when writing code:
    - `validation.js`: MCP tool input validation helper (`validateToolInput`)
    - `tempFileManager.js`: Temp file tracking and cleanup with process exit handlers
    - `urlValidator.js`: SSRF-safe URL validation for image downloads
-   - `logger.js`: Context-aware logging with request correlation
+   - `logger.js`: Context-aware logging with request correlation. Console transports must come from `createSafeConsoleTransport()` (which always sets `stderrLevels` so stdout stays clean for MCP stdio JSON-RPC frames). Bare `new winston.transports.Console(...)` outside this file is blocked by ESLint `no-restricted-syntax`.
    - `nqlSanitizer.js`: NQL query sanitization (consolidated from memberService and tierService)
    - `imageInputResolver.js`: Resolves image input from URL, local file path (with containment check against `GHOST_MCP_IMAGE_ROOT`), or base64 data
    - `formatErrorResponse.js`: Builds a consistent `{error, ghost?, extra?}` envelope for all MCP tool error responses. The optional `extra` arg is an arbitrary caller-supplied context object; if non-empty it is merged under a top-level `extra` key and sanitized alongside the rest. **MUST be used for every new MCP error path** — it is the only route through `sanitizeErrorPayload` and therefore the only way error text is guaranteed to be redacted before reaching MCP clients.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,18 @@ git checkout -b <type>/issue-<number>-<description>
 2. **Make changes** on the feature branch
 3. **Commit** with clear, descriptive messages
 4. **Push** to remote and create a pull request
-5. **Never commit directly to `main`** - branch protection on the remote enforces this. Local-only Claude Code hooks (gitignored, not tracked) also catch it before tokens are spent: `session-start-branch-check.sh` warns at session start; `block-main-branch-edits.sh` blocks edits and commits while on `main`.
+5. **Never commit directly to `main`** - branch protection on the remote enforces this. Claude Code hooks under `.claude/hooks/` also catch it before tokens are spent: `session-start-branch-check.sh` warns at session start; `block-main-branch-edits.sh` blocks edits and commits while on `main`.
+
+### Claude Code hook setup
+
+The four scripts under `.claude/hooks/` are tracked in git so they survive a fresh clone or new machine:
+
+- `session-start-branch-check.sh` (SessionStart): warns when HEAD is `main`.
+- `block-dangerous-git.sh` (PreToolUse / Bash): refuses `git commit/push --no-verify` and `git push --force` (allows `--force-with-lease`).
+- `block-main-branch-edits.sh` (PreToolUse / Edit | Write | Bash): refuses mutating actions while HEAD is `main`.
+- `block-mcp-resources.sh` (PreToolUse / Edit | Write): refuses MCP resource registration in `src/mcp_server*.js`.
+
+Per-user state is split out: `.claude/settings.local.json` (permission allowlist) and `.claude/plans/` (planning artifacts) stay gitignored. Hook bypass for legitimate exceptions: set `GHOST_MCP_HOOK_BYPASS=1` (logged to stderr).
 
 ## Project Overview
 
@@ -173,7 +184,7 @@ Follow these principles when writing code:
    - Implements Model Context Protocol specification with Zod validation
    - Exposes Ghost CMS functionality as 35 MCP tools across 7 domain types
    - Domain types: Posts, Pages, Tags, Members, Newsletters, Tiers, Images
-   - **Note:** This server provides tools only, not MCP protocol resources. A local-only Claude Code hook (`block-mcp-resources.sh`, gitignored) refuses edits to `src/mcp_server*.js` that try to register resources.
+   - **Note:** This server provides tools only, not MCP protocol resources. A Claude Code hook (`.claude/hooks/block-mcp-resources.sh`) refuses edits to `src/mcp_server*.js` that try to register resources.
    - Tools by domain:
      - **Posts** (6): `ghost_create_post`, `ghost_get_posts`, `ghost_get_post`, `ghost_search_posts`, `ghost_update_post`, `ghost_delete_post`
      - **Pages** (6): `ghost_create_page`, `ghost_get_pages`, `ghost_get_page`, `ghost_search_pages`, `ghost_update_page`, `ghost_delete_page`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ git checkout -b <type>/issue-<number>-<description>
 2. **Make changes** on the feature branch
 3. **Commit** with clear, descriptive messages
 4. **Push** to remote and create a pull request
-5. **Never commit directly to `main`** - branch protection on the remote enforces this, plus a SessionStart hook (`.claude/hooks/session-start-branch-check.sh`) and a PreToolUse hook (`.claude/hooks/block-main-branch-edits.sh`) catch the situation locally before any tokens are spent.
+5. **Never commit directly to `main`** - branch protection on the remote enforces this. Local-only Claude Code hooks (gitignored, not tracked) also catch it before tokens are spent: `session-start-branch-check.sh` warns at session start; `block-main-branch-edits.sh` blocks edits and commits while on `main`.
 
 ## Project Overview
 
@@ -150,6 +150,11 @@ Follow these principles when writing code:
    - Add comments only when the "why" isn't obvious from the code
    - Keep functions small and focused on a single responsibility
 
+5. **Use `logger`, never `console.*`, in service/util/controller code**
+   - `no-console: error` is enforced by ESLint for `src/services/**`, `src/utils/**`, `src/controllers/**`
+   - MCP server entrypoints (`src/mcp_server*.js`) may use `console.error`/`console.warn` (stderr-safe) but not `console.log`/`info`/`debug` (stdout = JSON-RPC channel)
+   - Import `createContextLogger` from `src/utils/logger.js` and use the returned context logger
+
 ### Code Quality Commands
 
 - `npm run lint` - Check code for linting errors
@@ -168,7 +173,7 @@ Follow these principles when writing code:
    - Implements Model Context Protocol specification with Zod validation
    - Exposes Ghost CMS functionality as 35 MCP tools across 7 domain types
    - Domain types: Posts, Pages, Tags, Members, Newsletters, Tiers, Images
-   - **Note:** This server provides tools only, not MCP protocol resources. A PreToolUse hook (`.claude/hooks/block-mcp-resources.sh`) refuses edits to `src/mcp_server*.js` that try to register resources.
+   - **Note:** This server provides tools only, not MCP protocol resources. A local-only Claude Code hook (`block-mcp-resources.sh`, gitignored) refuses edits to `src/mcp_server*.js` that try to register resources.
    - Tools by domain:
      - **Posts** (6): `ghost_create_post`, `ghost_get_posts`, `ghost_get_post`, `ghost_search_posts`, `ghost_update_post`, `ghost_delete_post`
      - **Pages** (6): `ghost_create_page`, `ghost_get_pages`, `ghost_get_page`, `ghost_search_pages`, `ghost_update_page`, `ghost_delete_page`

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,33 +38,74 @@ export default [
           caughtErrorsIgnorePattern: '^_',
         },
       ],
+      // Default off; per-path overrides below tighten this for MCP-touching code.
+      // Stdio MCP transport reserves stdout for JSON-RPC frames; console.log/info/debug
+      // route to stdout and would corrupt the protocol channel.
       'no-console': 'off',
-      // Prevent inline dynamic imports of services - use lazy-loaded variables instead
-      // See docs/SERVICE_PATTERNS.md for details
-      // Note: This rule catches variable declarations that use dynamic imports of services
-      // Pattern: const foo = await import('./services/...')
+      // Forbid joi in new code — Zod schemas under src/schemas/ are the project
+      // standard. The override block below allowlists the four legacy files
+      // that currently still import joi.
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'joi',
+              message: 'Use Zod schemas under src/schemas/. joi is allowed only in legacy files.',
+            },
+          ],
+        },
+      ],
+      // Forbid bare Console transport construction. The createSafeConsoleTransport
+      // factory in src/utils/logger.js is the single sanctioned construction site;
+      // bare `new winston.transports.Console(...)` would drop stderrLevels and
+      // corrupt MCP stdio output. Override below permits the factory's own file.
       'no-restricted-syntax': [
         'error',
         {
           selector:
-            'VariableDeclarator > AwaitExpression > ImportExpression[source.value*="ghostService"]',
+            "NewExpression[callee.object.object.name='winston'][callee.object.property.name='transports'][callee.property.name='Console']",
           message:
-            'Use lazy-loaded ghostService variable instead of inline dynamic imports. See docs/SERVICE_PATTERNS.md',
+            'Use createSafeConsoleTransport() from src/utils/logger.js — bare Console transports drop stderrLevels and corrupt MCP stdio.',
         },
+        // Service inline-dynamic-import bans. Lazy-load via loadServices() in
+        // src/mcp_server.js. See docs/SERVICE_PATTERNS.md.
         {
           selector:
-            'VariableDeclarator > AwaitExpression > ImportExpression[source.value*="pageService"]',
+            'VariableDeclarator > AwaitExpression > ImportExpression[source.value=/\\.\\/services\\/(ghost|post|page|newsletter|member|tier|image)Service|\\.\\/services\\/(posts|pages|tags|members|newsletters|tiers|images)/]',
           message:
-            'Use lazy-loaded pageService variable instead of inline dynamic imports. See docs/SERVICE_PATTERNS.md',
-        },
-        {
-          selector:
-            'VariableDeclarator > AwaitExpression > ImportExpression[source.value*="newsletterService"]',
-          message:
-            'Use lazy-loaded newsletterService variable instead of inline dynamic imports. See docs/SERVICE_PATTERNS.md',
+            'Use lazy-loaded service variable from loadServices() instead of inline dynamic import. See docs/SERVICE_PATTERNS.md',
         },
       ],
     },
+  },
+  // Allowlist legacy joi importers. Migrating these to Zod is out of scope here.
+  {
+    files: [
+      'src/utils/urlValidator.js',
+      'src/controllers/imageController.js',
+      'src/services/pageService.js',
+      'src/services/newsletterService.js',
+    ],
+    rules: { 'no-restricted-imports': 'off' },
+  },
+  // logger.js owns the only Console transport construction.
+  {
+    files: ['src/utils/logger.js'],
+    rules: { 'no-restricted-syntax': 'off' },
+  },
+  // Strict no-console for service/util/controller code: must use logger.
+  {
+    files: ['src/services/**/*.js', 'src/utils/**/*.js', 'src/controllers/**/*.js'],
+    ignores: ['**/__tests__/**'],
+    rules: { 'no-console': 'error' },
+  },
+  // MCP server entrypoints may emit startup/fatal banners on stderr only.
+  // console.log/info/debug remain forbidden because they default to stdout
+  // and would corrupt the stdio JSON-RPC channel.
+  {
+    files: ['src/mcp_server.js', 'src/mcp_server_enhanced.js'],
+    rules: { 'no-console': ['error', { allow: ['error', 'warn'] }] },
   },
   {
     ignores: ['node_modules/**', 'build/**', 'coverage/**', 'dist/**'],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,7 +8,7 @@ import prettierConfig from 'eslint-config-prettier';
 // referenced in both places.
 const SERVICE_INLINE_IMPORT_BAN = {
   selector:
-    'VariableDeclarator > AwaitExpression > ImportExpression[source.value=/\\.\\/services\\/(ghost|post|page|newsletter|member|tier|image)Service|\\.\\/services\\/(posts|pages|tags|members|newsletters|tiers|images)/]',
+    'VariableDeclarator > AwaitExpression > ImportExpression[source.value=/\\.\\/services\\/(ghost|post|page|newsletter|member|tier|imageProcessing|image)Service|\\.\\/services\\/(posts|pages|tags|members|newsletters|tiers|images)/]',
   message:
     'Use lazy-loaded service variable from loadServices() instead of inline dynamic import. See docs/SERVICE_PATTERNS.md',
 };
@@ -83,7 +83,9 @@ export default [
       ],
     },
   },
-  // Allowlist legacy joi importers. Migrating these to Zod is out of scope here.
+  // Allowlist legacy joi importers. urlValidator.js migration tracked in
+  // https://linear.app/jonathangardner/issue/JON-151 (SSRF parse-disagreement).
+  // The other three are data-shape validation, lower priority.
   {
     files: [
       'src/utils/urlValidator.js',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -94,9 +94,12 @@ export default [
     files: ['src/utils/logger.js'],
     rules: { 'no-restricted-syntax': 'off' },
   },
-  // Strict no-console for service/util/controller code: must use logger.
+  // Strict no-console for service/util/controller code and the Express
+  // entrypoint: must use logger. src/index.js shares the process with the
+  // MCP stdio transport, so a stray console.log there would corrupt the
+  // JSON-RPC channel — same risk class as the service layer.
   {
-    files: ['src/services/**/*.js', 'src/utils/**/*.js', 'src/controllers/**/*.js'],
+    files: ['src/services/**/*.js', 'src/utils/**/*.js', 'src/controllers/**/*.js', 'src/index.js'],
     ignores: ['**/__tests__/**'],
     rules: { 'no-console': 'error' },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,17 @@ import js from '@eslint/js';
 import prettier from 'eslint-plugin-prettier';
 import prettierConfig from 'eslint-config-prettier';
 
+// Extracted so the logger.js override can keep this ban active while dropping
+// only the Console-transport ban it actually needs to disable. ESLint flat
+// config rule overrides replace the rule entirely, so the selector has to be
+// referenced in both places.
+const SERVICE_INLINE_IMPORT_BAN = {
+  selector:
+    'VariableDeclarator > AwaitExpression > ImportExpression[source.value=/\\.\\/services\\/(ghost|post|page|newsletter|member|tier|image)Service|\\.\\/services\\/(posts|pages|tags|members|newsletters|tiers|images)/]',
+  message:
+    'Use lazy-loaded service variable from loadServices() instead of inline dynamic import. See docs/SERVICE_PATTERNS.md',
+};
+
 export default [
   js.configs.recommended,
   prettierConfig,
@@ -68,14 +79,7 @@ export default [
           message:
             'Use createSafeConsoleTransport() from src/utils/logger.js — bare Console transports drop stderrLevels and corrupt MCP stdio.',
         },
-        // Service inline-dynamic-import bans. Lazy-load via loadServices() in
-        // src/mcp_server.js. See docs/SERVICE_PATTERNS.md.
-        {
-          selector:
-            'VariableDeclarator > AwaitExpression > ImportExpression[source.value=/\\.\\/services\\/(ghost|post|page|newsletter|member|tier|image)Service|\\.\\/services\\/(posts|pages|tags|members|newsletters|tiers|images)/]',
-          message:
-            'Use lazy-loaded service variable from loadServices() instead of inline dynamic import. See docs/SERVICE_PATTERNS.md',
-        },
+        SERVICE_INLINE_IMPORT_BAN,
       ],
     },
   },
@@ -89,10 +93,12 @@ export default [
     ],
     rules: { 'no-restricted-imports': 'off' },
   },
-  // logger.js owns the only Console transport construction.
+  // logger.js owns the only Console transport construction. We drop only
+  // that ban here; the service-inline-import ban stays active so a future
+  // rogue dynamic import in this file would still be caught.
   {
     files: ['src/utils/logger.js'],
-    rules: { 'no-restricted-syntax': 'off' },
+    rules: { 'no-restricted-syntax': ['error', SERVICE_INLINE_IMPORT_BAN] },
   },
   // Strict no-console for service/util/controller code and the Express
   // entrypoint: must use logger. src/index.js shares the process with the

--- a/src/services/ghostService.js
+++ b/src/services/ghostService.js
@@ -33,7 +33,7 @@ const api = new GhostAdminAPI({
 const handleApiRequest = async (resource, action, data = {}, options = {}, retries = 3) => {
   if (!api[resource] || typeof api[resource][action] !== 'function') {
     const errorMsg = `Invalid Ghost API resource or action: ${resource}.${action}`;
-    console.error(errorMsg);
+    logger.error(errorMsg);
     throw new Error(errorMsg);
   }
 

--- a/src/services/ghostService.js
+++ b/src/services/ghostService.js
@@ -116,14 +116,6 @@ const handleApiRequest = async (resource, action, data = {}, options = {}, retri
 // Example function (will be expanded later)
 const getSiteInfo = async () => {
   return handleApiRequest('site', 'read');
-  // try {
-  //   const site = await api.site.read();
-  //   console.log("Connected to Ghost site:", site.title);
-  //   return site;
-  // } catch (error) {
-  //   console.error("Error connecting to Ghost Admin API:", error);
-  //   throw error; // Re-throw the error for handling upstream
-  // }
 };
 
 /**

--- a/src/utils/__tests__/logger.test.js
+++ b/src/utils/__tests__/logger.test.js
@@ -48,16 +48,9 @@ describe('logger', () => {
       vi.restoreAllMocks();
     });
 
-    it('configures the Console transport with stderrLevels covering every level', () => {
-      const consoleTransport = logger.transports.find((t) => t.name === 'console');
-      expect(consoleTransport).toBeDefined();
-      expect(consoleTransport.stderrLevels).toMatchObject({
-        error: true,
-        warn: true,
-        info: true,
-        debug: true,
-      });
-    });
+    // The stderrLevels contract is pinned by the createSafeConsoleTransport
+    // suite below. Routing tests below verify the runtime side: every level's
+    // bytes actually land on stderr, not stdout.
 
     // Drive the Console transport's log() directly. Winston's writable-stream
     // pipeline can defer writes across ticks, so routing the message through

--- a/src/utils/__tests__/logger.test.js
+++ b/src/utils/__tests__/logger.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { LEVEL, MESSAGE } from 'triple-beam';
-import { createContextLogger } from '../logger.js';
+import { createContextLogger, createSafeConsoleTransport } from '../logger.js';
 import logger from '../logger.js';
 
 describe('logger', () => {
@@ -75,6 +75,45 @@ describe('logger', () => {
       transport.log(makeInfo(level, `${level}-test`), () => {});
       expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining(`${level}-test`));
       expect(stdoutSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createSafeConsoleTransport', () => {
+    // Factory exists so the stderrLevels invariant cannot drift away from any
+    // future Console transport. Bare `new winston.transports.Console(...)` is
+    // forbidden by ESLint outside this module; this test pins the contract.
+
+    it('returns a winston Console transport', () => {
+      const t = createSafeConsoleTransport();
+      expect(t).toBeDefined();
+      expect(t.name).toBe('console');
+    });
+
+    it('always sets stderrLevels for every level', () => {
+      const t = createSafeConsoleTransport();
+      expect(t.stderrLevels).toMatchObject({
+        error: true,
+        warn: true,
+        info: true,
+        debug: true,
+      });
+    });
+
+    it('preserves caller-supplied options like level', () => {
+      const t = createSafeConsoleTransport({ level: 'warn' });
+      expect(t.level).toBe('warn');
+    });
+
+    it('forces stderrLevels even if caller tries to override it', () => {
+      // Defense in depth: a caller cannot accidentally narrow stderrLevels
+      // by passing their own array. This is the whole point of the factory.
+      const t = createSafeConsoleTransport({ stderrLevels: ['error'] });
+      expect(t.stderrLevels).toMatchObject({
+        error: true,
+        warn: true,
+        info: true,
+        debug: true,
+      });
     });
   });
 

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -14,6 +14,13 @@ const isDevelopment = process.env.NODE_ENV === 'development';
 // level later can't silently leave one transport routing to stdout.
 const ALL_LEVELS_TO_STDERR = ['error', 'warn', 'info', 'debug'];
 
+// Factory for Console transports. Always forces stderrLevels for all npm
+// levels — caller cannot narrow it. Bare `new winston.transports.Console(...)`
+// is forbidden by ESLint outside this module so this factory is the only way
+// to construct a Console transport in the project.
+const createSafeConsoleTransport = (options = {}) =>
+  new winston.transports.Console({ ...options, stderrLevels: ALL_LEVELS_TO_STDERR });
+
 // Define custom log format
 const logFormat = winston.format.combine(
   winston.format.timestamp({
@@ -47,18 +54,9 @@ const logger = winston.createLogger({
     service: 'ghost-mcp-server',
     pid: process.pid,
   },
-  transports: [
-    // Console output — route all levels to stderr so stdio MCP transport
-    // (which uses stdout for JSON-RPC frames) is not corrupted by log lines.
-    new winston.transports.Console({
-      level: isDevelopment ? 'debug' : 'info',
-      stderrLevels: ALL_LEVELS_TO_STDERR,
-    }),
-  ],
-  // Handle uncaught exceptions
-  exceptionHandlers: [new winston.transports.Console({ stderrLevels: ALL_LEVELS_TO_STDERR })],
-  // Handle unhandled promise rejections
-  rejectionHandlers: [new winston.transports.Console({ stderrLevels: ALL_LEVELS_TO_STDERR })],
+  transports: [createSafeConsoleTransport({ level: isDevelopment ? 'debug' : 'info' })],
+  exceptionHandlers: [createSafeConsoleTransport()],
+  rejectionHandlers: [createSafeConsoleTransport()],
 });
 
 // Add file logging in production
@@ -157,4 +155,4 @@ const createContextLogger = (context) => {
 };
 
 export default logger;
-export { createContextLogger };
+export { createContextLogger, createSafeConsoleTransport };


### PR DESCRIPTION
## Summary

Moves several CLAUDE.md \"MUST\" / \"do not\" rules from prose (which Claude has to remember every session) into mechanical enforcement layered by mechanism:

- **Layer 0** (code invariants): \`createSafeConsoleTransport()\` factory in \`src/utils/logger.js\` — bakes \`stderrLevels\` into every Console transport so the stdio-MCP-stdout-corruption class of bug becomes impossible.
- **Layer 1** (ESLint): \`no-console\` for service/util/controller code; \`no-restricted-imports\` for \`joi\`; \`no-restricted-syntax\` widened to all 9 services and to bare \`new winston.transports.Console(...)\` outside logger.js.
- **Layer 4** (Claude Code hooks, local-only): SessionStart branch check; PreToolUse blockers for \`--no-verify\` / \`--force\`, edits while on \`main\`, and MCP resource registration in \`src/mcp_server*.js\`.

Each scar-tissue rule in CLAUDE.md was replaced with a one-line breadcrumb pointing at the mechanism that now enforces it.

## Why this and not just hooks?

The first cut of this work was hooks-only and would have duplicated rules better expressed in ESLint or eliminated by code refactor. Hooks only protect Claude; ESLint also protects me, future contributors, and CI. Hooks are the right primitive only for behavioral / process invariants no static check can express (\`--no-verify\`, current branch, MCP resource policy).

## Test plan

- [x] \`npm run lint\` clean on existing source.
- [x] \`npm test\` — 1399/1399 pass.
- [x] Each new ESLint rule smoke-tested with a scratch violation file (all 4 rules fire correctly).
- [x] Each hook smoke-tested with should-block and should-allow inputs (H1 had a false-positive bug on \`--no-verify\` in commit message bodies; refactored to use shlex token parsing and re-verified).
- [x] Logger factory has dedicated tests for the stderrLevels invariant being non-narrowable.
- [ ] After merge: confirm SessionStart hook fires in a fresh Claude Code session and injects context only when on \`main\`.