### PR TITLE
chore(deps): bump axios 1.15.0 → 1.16.0 (GHSA-w9j2-pvgh-6h63)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2122,11 +2122,12 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }


### PR DESCRIPTION
## Summary

Bump `axios` 1.15.0 → 1.16.0 in `package-lock.json` to clear `GHSA-w9j2-pvgh-6h63` (HIGH) plus 12 related axios advisories. Pure lockfile refresh — `package.json`'s `^1.15.0` range already permits 1.16.0, so no manifest changes.

This commit was originally part of the now-closed #169 (superseded by #166/#171); cherry-picked here as a focused dependency bump.

## Advisories cleared

- `GHSA-w9j2-pvgh-6h63` (HIGH) — Authentication Bypass via Prototype Pollution Gadget in `validateStatus`
- `GHSA-pmwg-cvhr-8vh7` — Incomplete fix for CVE-2025-62718 (NO_PROXY bypass via 127.0.0.0/8)
- `GHSA-3w6x-2g7m-8v23` — Invisible JSON Response Tampering via `parseReviver`
- `GHSA-q8qp-cvcw-x6jj` — Prototype pollution read-side gadgets in HTTP adapter
- `GHSA-xhjh-pmcv-23jw` — Null Byte Injection via Reverse-Encoding in `AxiosURLSearchParams`
- `GHSA-445q-vr5w-6q77` — CRLF Injection in `multipart/form-data` body via unsanitized `blob.type`
- `GHSA-m7pr-hjqh-92cm` — `no_proxy` bypass via IP alias allows SSRF
- `GHSA-62hf-57xw-28j9` — Unbounded recursion in `toFormData` causes DoS
- `GHSA-5c9x-8gcm-mpgx` — Streamed uploads bypass `maxBodyLength` when `maxRedirects: 0`
- `GHSA-vf2m-468p-8v99` — Streamed responses bypass `maxContentLength`
- `GHSA-pf86-5x62-jrwf` — Prototype Pollution Gadgets — response tampering, exfiltration, hijacking
- `GHSA-6chq-wfr3-2hj9` — Header Injection via Prototype Pollution
- `GHSA-xx6v-rp6x-q39c` — XSRF Token Cross-Origin Leakage via `withXSRFToken` Boolean Coercion

## Context

The CI `build` job runs `npm audit --omit=dev --audit-level=high` and was failing on every PR against `main` (e.g. PR #173) solely because of the axios 1.15.0 advisories. This PR resolves the axios portion.

**Note:** A new `fast-uri` HIGH advisory (`GHSA-q3j6-qgpj-74h6`, `GHSA-v39h-62p7-jpjc`) has also surfaced and is already being addressed by Dependabot PR #174. Both PRs need to land for the `build` audit gate to go green; with axios alone, audit still exits 1 on `fast-uri`.

## Test plan

- [x] `npm install` — applied the lockfile cleanly
- [x] `npm run lint` — clean
- [x] `npm test` — 1399/1399 passing
- [x] `npm audit --omit=dev --audit-level=high` — axios advisories no longer reported (only fast-uri/postcss remain, tracked separately)
- [ ] CI `build` check — expected to still fail on `fast-uri` until #174 merges; cross-verify after both land

🤖 Generated with [Claude Code](https://claude.ai/code)