### PR TITLE
fix(security): migrate urlValidator.js from Joi to Zod (JON-151)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -83,12 +83,11 @@ export default [
       ],
     },
   },
-  // Allowlist legacy joi importers. urlValidator.js migration tracked in
-  // https://linear.app/jonathangardner/issue/JON-151 (SSRF parse-disagreement).
-  // The other three are data-shape validation, lower priority.
+  // Allowlist legacy joi importers. These three validate data shape, not a
+  // security boundary, and can be migrated to Zod separately. urlValidator.js
+  // was migrated in JON-151 (SSRF parse-disagreement) and is no longer here.
   {
     files: [
-      'src/utils/urlValidator.js',
       'src/controllers/imageController.js',
       'src/services/pageService.js',
       'src/services/newsletterService.js',

--- a/src/utils/__tests__/urlValidator.test.js
+++ b/src/utils/__tests__/urlValidator.test.js
@@ -377,6 +377,40 @@ describe('urlValidator', () => {
         expect(result.isValid).toBe(true);
       });
     });
+
+    // Regression tests for JON-151: the previous two-parser sequence
+    // (Joi.uri() + new URL()) could disagree on these edge cases, opening a
+    // path-around-isSafeHost SSRF window. The single-parser pipeline must
+    // either reject these or canonicalize them consistently with new URL().
+    describe('parse-disagreement regressions (JON-151)', () => {
+      it('should reject credentials-prefixed URL whose true host is private (127.0.0.1)', () => {
+        // WHATWG: hostname is 127.0.0.1. A naive parser that split on '@' the
+        // wrong way could see "imgur.com" and let this through. isSafeHost
+        // must see 127.0.0.1 and reject.
+        const result = validateImageUrl('https://imgur.com@127.0.0.1/image.jpg');
+        expect(result.isValid).toBe(false);
+      });
+
+      it('should reject Unicode hostname not on the allowlist', () => {
+        // new URL('https://☃.com/') canonicalizes the host to xn--n3h.com
+        // (Punycode). Either form must be rejected — neither is allowlisted.
+        const result = validateImageUrl('https://☃.com/image.jpg');
+        expect(result.isValid).toBe(false);
+      });
+
+      it('should reject Punycode hostname not on the allowlist', () => {
+        const result = validateImageUrl('https://xn--n3h.com/image.jpg');
+        expect(result.isValid).toBe(false);
+      });
+
+      it('should reject IPv6 loopback with zone ID', () => {
+        // [::1%25eth0] is the percent-encoded form of [::1%eth0]. The host is
+        // still ::1 — the SSRF guard must catch it regardless of whether the
+        // parser accepts the zone-ID syntax or rejects the URL outright.
+        const result = validateImageUrl('http://[::1%25eth0]/image.jpg');
+        expect(result.isValid).toBe(false);
+      });
+    });
   });
 
   describe('createSecureAxiosConfig', () => {

--- a/src/utils/urlValidator.js
+++ b/src/utils/urlValidator.js
@@ -1,4 +1,4 @@
-import Joi from 'joi';
+import { z } from 'zod';
 import { URL } from 'url';
 
 // Configure allowed domains for image downloads
@@ -69,6 +69,25 @@ const isSafeHost = (hostname) => {
   );
 };
 
+// Single-parser URL schema. z.string().url() uses the WHATWG URL parser
+// (same engine as new URL() below), so the schema check and the subsequent
+// hostname extraction cannot disagree on edge cases like embedded
+// credentials, IDN/Unicode, or IPv6 zone IDs. See JON-151.
+const urlSchema = z
+  .string()
+  .url()
+  .refine(
+    (s) => {
+      try {
+        const proto = new URL(s).protocol;
+        return proto === 'http:' || proto === 'https:';
+      } catch {
+        return false;
+      }
+    },
+    { message: 'must use http or https scheme' }
+  );
+
 /**
  * Validates and sanitizes a URL for safe external requests
  * @param {string} url - The URL to validate
@@ -76,19 +95,11 @@ const isSafeHost = (hostname) => {
  */
 const validateImageUrl = (url) => {
   try {
-    // Basic URL validation with Joi
-    const urlSchema = Joi.string()
-      .uri({
-        scheme: ['http', 'https'],
-        allowRelative: false,
-      })
-      .required();
-
-    const validation = urlSchema.validate(url);
-    if (validation.error) {
+    const result = urlSchema.safeParse(url);
+    if (!result.success) {
       return {
         isValid: false,
-        error: `Invalid URL format: ${validation.error.details[0].message}`,
+        error: `Invalid URL format: ${result.error.issues[0].message}`,
       };
     }
 


### PR DESCRIPTION
## Summary

- `src/utils/urlValidator.js` is the project's sole SSRF guard. It validated URLs with `Joi.string().uri()` and then re-parsed the same string with `new URL()` for hostname extraction. The two parsers can disagree on edge cases (embedded credentials, IDN/Unicode, IPv6 zone IDs, unusual percent-encoding), creating a window where Joi accepts a string but `new URL()` extracts a different hostname — letting `isSafeHost()` check the wrong host.
- Swap the Joi schema for `z.string().url()`. Zod's `.url()` uses the WHATWG URL parser internally — same engine as `new URL()` — so the schema and the hostname extraction agree by construction. A `.refine()` preserves the `http(s)`-only scheme allowlist that Joi enforced.
- Remove `src/utils/urlValidator.js` from the joi allowlist in `eslint.config.js`; the project-wide joi ban now applies to it (allowlist trimmed 4 → 3).
- Add regression tests for embedded credentials, Unicode hostname, Punycode hostname, and IPv6 loopback with zone ID.

Closes JON-151.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx prettier --check` on touched files — clean
- [x] `npx vitest run src/utils/__tests__/urlValidator.test.js` — 97/97 pass (93 existing + 4 new regression tests)
- [x] `npm test` — full suite 1403/1403 pass
- [ ] CI green on the PR