### PR TITLE
ci: add Dependabot config for grouped weekly dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+# Dependabot configuration
+#
+# Governs version-update and security-update PRs (NOT Security-tab alert
+# triage — that is handled by Dependabot auto-triage rules in repo Settings).
+#
+# Noise is kept low by grouping minor/patch bumps into a few batched PRs per
+# ecosystem and running on a weekly cadence. Major bumps are intentionally left
+# ungrouped so they get individual review.
+#
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        update-types: ["minor", "patch"]
+      development-dependencies:
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: "ci"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,5 +36,6 @@ updates:
     groups:
       github-actions:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
     commit-message:
       prefix: "ci"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to reduce dependency-update noise while keeping deps current.

- **npm** + **github-actions** ecosystems, **weekly** (Monday) schedule
- Minor/patch bumps **grouped** into a few batched PRs (prod vs dev separately); majors stay ungrouped for individual review
- `open-pull-requests-limit: 5` per ecosystem
- Commit prefixes match repo convention (`chore(deps)` / `chore(deps-dev)` / `ci`)

## Context

Follow-up to dismissing two dev-only transitive security alerts (`ip-address` #117, `picomatch` #70) — both bundled inside semantic-release's npm CLI, absent from the production tree and published package.

## Scope note

This file governs **version/security-update PRs**, not Security-tab alert triage. Auto-dismissal of low-impact dev-scope advisories is handled by Dependabot **auto-triage rules** (already partially active — `brace-expansion` #126 was auto-dismissed); being extended separately.

## Verification

- `dependabot.yml` parses as valid YAML (`version: 2`, ecosystems: npm, github-actions)
- Confirmed github-actions ecosystem tracks real actions in use (checkout, setup-node, claude-code-action, codeql-action)